### PR TITLE
Call PlannerCallback's from OMPLSimplifier

### DIFF
--- a/include/or_ompl/OMPLConversions.h
+++ b/include/or_ompl/OMPLConversions.h
@@ -35,6 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define OMPLCONVERSIONS_H_
 #include <ompl/util/Console.h>
 #include <ompl/base/spaces/RealVectorStateSpace.h>
+#include <ompl/geometric/PathGeometric.h>
 #include <openrave/openrave.h>
 #include "OMPLPlannerParameters.h"
 
@@ -50,6 +51,10 @@ public:
 
 RealVectorSpacePtr CreateStateSpace(OpenRAVE::RobotBasePtr const robot,
                                     OMPLPlannerParameters const &params);
+
+OpenRAVE::PlannerStatus ToORTrajectory(OpenRAVE::RobotBasePtr const &robot,
+                                       ompl::geometric::PathGeometric const &ompl_traj,
+                                       OpenRAVE::TrajectoryBasePtr or_traj);
 
 }
 

--- a/include/or_ompl/OMPLPlanner.h
+++ b/include/or_ompl/OMPLPlanner.h
@@ -78,8 +78,6 @@ private:
     ompl::base::PlannerPtr CreatePlanner(OMPLPlannerParameters const &params);
     bool IsStateValid(const ompl::base::State* state);
     bool IsInOrCollision(std::vector<double> const &jointValues);
-    OpenRAVE::PlannerStatus ToORTrajectory(ompl::geometric::PathGeometric &ompl_traj,
-                                           OpenRAVE::TrajectoryBasePtr or_traj) const;
 
     bool GetParametersCommand(std::ostream &sout, std::istream &sin) const;
 };

--- a/src/OMPLSimplifier.cpp
+++ b/src/OMPLSimplifier.cpp
@@ -35,6 +35,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "OMPLConversions.h"
 #include "OMPLSimplifer.h"
 
+using OpenRAVE::PA_None;
+using OpenRAVE::PA_Interrupt;
+using OpenRAVE::PA_ReturnWithAnySolution;
+
+using OpenRAVE::PS_HasSolution;
+using OpenRAVE::PS_InterruptedWithSolution;
+
 namespace or_ompl
 {
 
@@ -132,8 +139,9 @@ OpenRAVE::PlannerStatus OMPLSimplifier::PlanPath(OpenRAVE::TrajectoryBasePtr ptr
     }
 
     // Run path simplification.
+    OpenRAVE::PlannerBase::PlannerProgress progress;
+    OpenRAVE::PlannerAction planner_action = PA_None;
     double const length_before = path.length();
-    int num_iterations = 0;
     int num_changes = 0;
 
     ompl::time::duration const time_limit
@@ -158,21 +166,27 @@ OpenRAVE::PlannerStatus OMPLSimplifier::PlanPath(OpenRAVE::TrajectoryBasePtr ptr
         //                 vertices
         bool const changed = m_simplifier->shortcutPath(path, 1, 1, 1.0, 0.005);
 
-        time_current = ompl::time::now();
-        num_iterations += 1;
         num_changes += !!changed;
-    } while (time_current - time_before <= time_limit);
+        progress._iteration += 1;
+
+        // Call any user-registered callbacks. These functions can terminate
+        // planning early.
+        planner_action = _CallCallbacks(progress);
+
+        time_current = ompl::time::now();
+    } while (time_current - time_before <= time_limit
+          && planner_action == PA_None);
 
     double const length_after = path.length();
 
     RAVELOG_DEBUG(
         "Ran %d iterations of smoothing over %.3f seconds. %d of %d iterations"
         " (%.2f%%) were effective. Reduced path length from %.3f to %.3f.\n",
-        num_iterations,
+        progress._iteration,
         ompl::time::seconds(time_current - time_before),
         num_changes,
-        num_iterations,
-        100 * static_cast<double>(num_changes) / num_iterations,
+        progress._iteration,
+        100 * static_cast<double>(num_changes) / progress._iteration,
         length_before, length_after
     );
 
@@ -182,17 +196,13 @@ OpenRAVE::PlannerStatus OMPLSimplifier::PlanPath(OpenRAVE::TrajectoryBasePtr ptr
     BOOST_ASSERT(ptraj);
     ptraj->Remove(0, ptraj->GetNumWaypoints());
 
-    for (size_t iwaypoint = 0; iwaypoint < path.getStateCount(); ++iwaypoint) {
-        ompl::base::State const *waypoint_generic = path.getState(iwaypoint);
-        StateType const &waypoint_ompl = *waypoint_generic->as<StateType>();
+    ToORTrajectory(m_robot, path, ptraj);
 
-        std::vector<OpenRAVE::dReal> waypoint_openrave(num_dof);
-        for (size_t idof = 0; idof < num_dof; ++idof) {
-            waypoint_openrave[idof] = waypoint_ompl[idof];
-        }
-        ptraj->Insert(iwaypoint, waypoint_openrave, m_cspec);
+    if (planner_action == PA_None) {
+        return PS_HasSolution;
+    } else {
+        return PS_InterruptedWithSolution;
     }
-    return OpenRAVE::PS_HasSolution;
 }
 
 bool OMPLSimplifier::IsInOrCollision(std::vector<double> const &values)


### PR DESCRIPTION
This is similar to the pending support for anytime planners #7, but for the path simplifier. The user can terminate planning early by registering a planner callback that returns `PA_Interrupt` or `PA_ReturnWithAnySolution`.
