### PR TITLE
Fix eigen capitalization, so depending packages compile

### DIFF
--- a/catkin.cmake
+++ b/catkin.cmake
@@ -10,7 +10,7 @@ find_package(Eigen REQUIRED)
 catkin_package(
     INCLUDE_DIRS include/
     LIBRARIES ${PROJECT_NAME}
-    DEPENDS Boost eigen OMPL OpenRAVE
+    DEPENDS Boost Eigen OMPL OpenRAVE
 )
 
 include_directories(


### PR DESCRIPTION
Compiling a dependent package failed for me with this error:

```
In file included from ws/src/or_ompl/include/or_ompl/TSRChain.h:4:0,
                 from ws/src/or_ompl/include/or_ompl/OMPLPlannerParameters.h:41,
                 from ws/src/or_ompl/include/or_ompl/OMPLPlanner.h:42,
                 from ws/src/ompl_setup_test/main.cpp:2:
ws/src/or_ompl/include/or_ompl/TSR.h:4:23: fatal error: Eigen/Dense: No such file or directory
```

Fixing the capitalization to match that used in the `find_package` invocation fixed the issue.