### PR TITLE
Merge multiple DOFs into one statespace

### DIFF
--- a/include/or_ompl/RobotStateSpace.h
+++ b/include/or_ompl/RobotStateSpace.h
@@ -20,14 +20,13 @@ namespace or_ompl {
          * Constuctor - all dof values are initialized to 0
          * @param dof_indices The dof indices this state will represent
          */
-        RobotState(const std::vector<int> &dof_indices, const std::vector<bool>& is_continuous);
+        RobotState(RobotStateSpace* stateSpace);
 
         /**
          * Clear the indices vector
          */
         ~RobotState();
 
-        void enforceBounds();
 
         /**
          * Gets a reference to the value at index i.
@@ -46,15 +45,10 @@ namespace or_ompl {
          */
         std::vector<double> getValues() const;
 
-        /**
-         * @return An ordered list of indices this state corresponds to
-         */
-        std::vector<int> getIndices() const { return _indices; }
+        const RobotStateSpace*  getSpace() const { return _stateSpace; }
 
     private:
-        std::vector<int> _indices;
-        std::vector<bool> _isContinuous;
-
+        RobotStateSpace* _stateSpace;
     };
 
     /**
@@ -84,6 +78,11 @@ namespace or_ompl {
          * Set the upper/lower bounds of the state space.
          */
         void setBounds(const ompl::base::RealVectorBounds& bounds);
+
+        /**
+         * @return An ordered list of indices this state corresponds to
+         */
+        const std::vector<int>& getIndices() const { return _indices; }
 
     private:
         std::vector<int> _indices;

--- a/src/OMPLConversions.cpp
+++ b/src/OMPLConversions.cpp
@@ -209,7 +209,6 @@ OpenRAVE::PlannerStatus ToORTrajectory(
                           "State is not a RealVectorStateSpace::StateType.");
             return OpenRAVE::PS_Failed;
         }
-        state->enforceBounds();
         or_traj->Insert(i, state->getValues(), true);
     }
     return OpenRAVE::PS_HasSolution;

--- a/src/OMPLPlanner.cpp
+++ b/src/OMPLPlanner.cpp
@@ -383,7 +383,7 @@ bool OMPLPlanner::IsStateValid(ompl::base::State const *state)
         }
     }
     
-    return !IsInOrCollision(realVectorState->getValues(), realVectorState->getIndices());
+    return !IsInOrCollision(realVectorState->getValues(), realVectorState->getSpace()->getIndices());
 }
 
 bool OMPLPlanner::GetParametersCommand(std::ostream &sout, std::istream &sin) const

--- a/src/OMPLSimplifier.cpp
+++ b/src/OMPLSimplifier.cpp
@@ -134,7 +134,6 @@ OpenRAVE::PlannerStatus OMPLSimplifier::PlanPath(OpenRAVE::TrajectoryBasePtr ptr
         for (size_t idof = 0; idof < num_dof; ++idof) {
             waypoint_ompl[idof] = waypoint_openrave[idof];
         }
-        waypoint_ompl->enforceBounds();
         path.append(waypoint_ompl.get());
     }
 
@@ -217,7 +216,7 @@ bool OMPLSimplifier::IsStateValid(ompl::base::State const *state)
     RobotState const *realVectorState = state->as<RobotState>();
 
     if (realVectorState) {
-        return !IsInOrCollision(realVectorState->getValues(), realVectorState->getIndices());
+        return !IsInOrCollision(realVectorState->getValues(), realVectorState->getSpace()->getIndices());
     } else {
         RAVELOG_ERROR("Invalid StateType. This should never happen.\n");
         return false;

--- a/src/RobotStateSpace.cpp
+++ b/src/RobotStateSpace.cpp
@@ -86,7 +86,6 @@ void RobotStateSpace::setBounds(const ompl::base::RealVectorBounds& bounds) {
             continue;
         }
         else {
-            // TODO: THIS AINT RIGHT
             ompl::base::RealVectorStateSpace* space = components_[i]->as<ompl::base::RealVectorStateSpace>();
             ompl::base::RealVectorBounds subBounds(space->getDimension());
 

--- a/src/TSRGoal.cpp
+++ b/src/TSRGoal.cpp
@@ -55,7 +55,7 @@ double TSRGoal::distanceGoal(const ompl::base::State *state) const {
 	// Put the robot in the pose that is represented in the state
 	const RobotState* mstate = state->as<RobotState>();
     unsigned int check_limits = 0; // The planner does this
-    _robot->SetDOFValues(mstate->getValues(), check_limits, mstate->getIndices());
+    _robot->SetDOFValues(mstate->getValues(), check_limits, mstate->getSpace()->getIndices());
 
 	// Get the end effector transform
 	OpenRAVE::Transform or_tf = active_manip->GetEndEffectorTransform();
@@ -121,7 +121,7 @@ void TSRGoal::sampleGoal(ompl::base::State *state) const {
 			RobotState* mstate = state->as<RobotState>();
 
             std::vector<int> arm_indices = _robot->GetActiveManipulator()->GetArmIndices();
-            std::vector<int> state_indices = mstate->getIndices();
+            std::vector<int> state_indices = mstate->getSpace()->getIndices();
 			for(unsigned int idx=0; idx < ik_solution.size(); idx++){
 
                 unsigned int sidx = std::find(state_indices.begin(),


### PR DESCRIPTION
This PR merges concurrent blocks of joints into one state space. Blocks are broken by continuous joints.

So a state space like this:

```
limited_1 -> limited_2 -> continuous -> limited_3 -> limited_4
```

becomes
```
[limited_1, limited_2] -> continuous -> [limited_3, limited_4]
```

Also got rid of the redundant "enforcebounds" function which was supposed to wrap joint values to be between -pi and pi (which SO2 state spaces already do).