### PR TITLE
Small PlannerParams fixes

### DIFF
--- a/catkin.cmake
+++ b/catkin.cmake
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 2.8.3)
+include(CheckCXXSourceCompiles)
 
 find_package(catkin REQUIRED cmake_modules openrave_catkin)
 find_package(Boost REQUIRED COMPONENTS chrono system)
@@ -6,6 +7,19 @@ find_package(OMPL REQUIRED)
 find_package(OpenRAVE REQUIRED)
 find_package(TinyXML REQUIRED)
 find_package(Eigen REQUIRED)
+
+# 2013-01-05: int options arg added to PlannerParameters::serialize
+set(CMAKE_REQUIRED_INCLUDES ${OpenRAVE_INCLUDE_DIRS})
+set(CMAKE_REQUIRED_LIBRARIES ${OpenRAVE_LIBRARIES} ${Boost_LIBRARIES})
+check_cxx_source_compiles(
+    "#include <openrave/openrave.h>
+    class P: OpenRAVE::PlannerBase::PlannerParameters
+    {void f(){bool (P::*x)(std::ostream&,int) const = &P::serialize;}};
+    int main(){}"
+    OR_HAS_PPSEROPTS)
+if(OR_HAS_PPSEROPTS)
+  add_definitions(-DOR_HAS_PPSEROPTS=1)
+endif()
 
 catkin_package(
     INCLUDE_DIRS include/

--- a/catkin.cmake
+++ b/catkin.cmake
@@ -16,19 +16,21 @@ check_cxx_source_compiles(
     class P: OpenRAVE::PlannerBase::PlannerParameters
     {void f(){bool (P::*x)(std::ostream&,int) const = &P::serialize;}};
     int main(){}"
-    OR_HAS_PPSEROPTS)
-if(OR_HAS_PPSEROPTS)
-  add_definitions(-DOR_HAS_PPSEROPTS=1)
-endif()
+    OR_OMPL_HAS_PPSEROPTS)
+configure_file(
+    include/${PROJECT_NAME}/config.h.in
+    ${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}/config.h
+)
 
 catkin_package(
-    INCLUDE_DIRS include/
+    INCLUDE_DIRS include ${CATKIN_DEVEL_PREFIX}/include
     LIBRARIES ${PROJECT_NAME}
     DEPENDS Boost Eigen OMPL OpenRAVE
 )
 
 include_directories(
-    include/${PROJECT_NAME}
+    include
+    ${CATKIN_DEVEL_PREFIX}/include
     ${Boost_INCLUDE_DIRS}
     ${Eigen_INCLUDE_DIRS}
     ${OMPL_INCLUDE_DIRS}
@@ -92,7 +94,12 @@ install(TARGETS or_ompl
 )
 install(DIRECTORY "include/${PROJECT_NAME}/"
     DESTINATION "${CATKIN_PACKAGE_INCLUDE_DESTINATION}"
+    PATTERN "*.in" EXCLUDE
     PATTERN ".svn" EXCLUDE
+)
+install(DIRECTORY
+    "${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}/"
+    DESTINATION "${CATKIN_PACKAGE_INCLUDE_DESTINATION}"
 )
 
 # Tests

--- a/include/or_ompl/OMPLConversions.h
+++ b/include/or_ompl/OMPLConversions.h
@@ -36,8 +36,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ompl/util/Console.h>
 #include <ompl/geometric/PathGeometric.h>
 #include <openrave/openrave.h>
-#include "OMPLPlannerParameters.h"
-#include "RobotStateSpace.h"
+#include <or_ompl/OMPLPlannerParameters.h>
+#include <or_ompl/RobotStateSpace.h>
 
 namespace or_ompl {
 

--- a/include/or_ompl/OMPLModule.h
+++ b/include/or_ompl/OMPLModule.h
@@ -8,7 +8,7 @@
 #ifndef OMPLMODULE_H_
 #define OMPLMODULE_H_
 
-#include "OMPLPlanner.h"
+#include <or_ompl/OMPLPlanner.h>
 #include <openrave/module.h>
 
 namespace or_ompl

--- a/include/or_ompl/OMPLPlanner.h
+++ b/include/or_ompl/OMPLPlanner.h
@@ -39,7 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <openrave/planningutils.h>
 #include <ompl/geometric/SimpleSetup.h>
 
-#include "OMPLPlannerParameters.h"
+#include <or_ompl/OMPLPlannerParameters.h>
 
 namespace or_ompl
 {

--- a/include/or_ompl/OMPLPlannerParameters.h
+++ b/include/or_ompl/OMPLPlannerParameters.h
@@ -38,7 +38,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <openrave/planner.h>
 #include <boost/foreach.hpp>
 #include <boost/make_shared.hpp>
-#include "TSRChain.h"
+#include <or_ompl/config.h>
+#include <or_ompl/TSRChain.h>
 
 namespace or_ompl
 {
@@ -68,7 +69,7 @@ public:
 
 protected:
 
-#ifdef OR_HAS_PPSEROPTS
+#ifdef OR_OMPL_HAS_PPSEROPTS
     virtual bool serialize(std::ostream& O, int options=0) const
     {
         if (!PlannerParameters::serialize(O, options)) {

--- a/include/or_ompl/OMPLPlannerParameters.h
+++ b/include/or_ompl/OMPLPlannerParameters.h
@@ -48,7 +48,7 @@ public:
     OMPLPlannerParameters()
         : m_seed(0)
         , m_timeLimit(10)
-        , m_isProcessing(false)
+        , m_isProcessingOMPL(false)
         , m_dat_filename("")
         , m_trajs_fileformat("")
     {
@@ -61,17 +61,26 @@ public:
 
     unsigned int m_seed;
     double m_timeLimit;
-    bool m_isProcessing;
+    bool m_isProcessingOMPL;
     std::string m_dat_filename;
     std::string m_trajs_fileformat;
     std::vector<TSRChain::Ptr> m_tsrchains;
 
 protected:
+
+#ifdef OR_HAS_PPSEROPTS
+    virtual bool serialize(std::ostream& O, int options=0) const
+    {
+        if (!PlannerParameters::serialize(O, options)) {
+            return false;
+        }
+#else
     virtual bool serialize(std::ostream& O) const
     {
         if (!PlannerParameters::serialize(O)) {
             return false;
         }
+#endif
 
         O << "<seed>" << m_seed << "</seed>" << std::endl;
         O << "<time_limit>" << m_timeLimit << "</time_limit>" << std::endl;
@@ -87,7 +96,7 @@ protected:
     ProcessElement startElement(std::string const &name,
                                 std::list<std::pair<std::string, std::string> > const &atts)
     {
-        if (m_isProcessing) {
+        if (m_isProcessingOMPL) {
             return PE_Ignore;
         }
 
@@ -100,19 +109,19 @@ protected:
                 return PE_Ignore;
         }
 
-        m_isProcessing =
+        m_isProcessingOMPL =
              name == "seed"
           || name == "time_limit"
           || name == "dat_filename"
           || name == "trajs_fileformat"
           || name == "tsr_chain";
 
-        return m_isProcessing ? PE_Support : PE_Pass;
+        return m_isProcessingOMPL ? PE_Support : PE_Pass;
     }
 
     virtual bool endElement(std::string const &name)
     {
-        if (m_isProcessing) {
+        if (m_isProcessingOMPL) {
             if (name == "seed") {
                 _ss >> m_seed;
             } else if (name == "time_limit") {
@@ -132,7 +141,7 @@ protected:
             } else {
                 RAVELOG_WARN(str(boost::format("unknown tag %s\n") % name));
             }
-            m_isProcessing = false;
+            m_isProcessingOMPL = false;
             return false;
         }
 

--- a/include/or_ompl/OMPLSimplifer.h
+++ b/include/or_ompl/OMPLSimplifer.h
@@ -35,7 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <openrave-core.h>
 #include <openrave/planner.h>
 #include <ompl/geometric/PathSimplifier.h>
-#include "OMPLPlannerParameters.h"
+#include <or_ompl/OMPLPlannerParameters.h>
 
 namespace or_ompl
 {

--- a/include/or_ompl/TSRChain.h
+++ b/include/or_ompl/TSRChain.h
@@ -1,8 +1,8 @@
 #ifndef OMPL_TSR_CHAIN_H_
 #define OMPL_TSR_CHAIN_H_
 
-#include "TSR.h"
-#include "TSRRobot.h"
+#include <or_ompl/TSR.h>
+#include <or_ompl/TSRRobot.h>
 
 #include <vector>
 #include <boost/shared_ptr.hpp>

--- a/include/or_ompl/TSRGoal.h
+++ b/include/or_ompl/TSRGoal.h
@@ -1,8 +1,8 @@
 #ifndef TSR_GOAL_H_
 #define TSR_GOAL_H_
 
-#include "TSR.h"
-#include "TSRChain.h"
+#include <or_ompl/TSR.h>
+#include <or_ompl/TSRChain.h>
 #include <openrave-core.h>
 #include <ompl/base/goals/GoalSampleableRegion.h>
 #include <ompl/base/SpaceInformation.h>

--- a/include/or_ompl/TSRRobot.h
+++ b/include/or_ompl/TSRRobot.h
@@ -1,7 +1,7 @@
 #ifndef OMPL_TSR_ROBOT_H_
 #define OMPL_TSR_ROBOT_H_
 
-#include "TSR.h"
+#include <or_ompl/TSR.h>
 #include <openrave/openrave.h>
 #include <boost/shared_ptr.hpp>
 

--- a/include/or_ompl/config.h.in
+++ b/include/or_ompl/config.h.in
@@ -1,0 +1,1 @@
+#cmakedefine OR_OMPL_HAS_PPSEROPTS 1

--- a/scripts/wrap_planners.py
+++ b/scripts/wrap_planners.py
@@ -36,7 +36,7 @@ factory_frontmatter = """\
 #include <string>
 #include <boost/assign/list_of.hpp>
 {includes:s}
-#include "PlannerRegistry.h"
+#include <or_ompl/PlannerRegistry.h>
 
 namespace or_ompl {{
 namespace registry {{

--- a/src/OMPLConversions.cpp
+++ b/src/OMPLConversions.cpp
@@ -34,7 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <boost/make_shared.hpp>
 #include <ompl/config.h>
-#include "OMPLConversions.h"
+#include <or_ompl/OMPLConversions.h>
 
 #define OMPL_VERSION_COMP (  OMPL_MAJOR_VERSION * 1000000 \
                            + OMPL_MINOR_VERSION * 1000 \

--- a/src/OMPLMain.cpp
+++ b/src/OMPLMain.cpp
@@ -35,10 +35,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <boost/function.hpp>
 #include <boost/make_shared.hpp>
 #include <openrave/plugin.h>
-#include "OMPLPlanner.h"
-#include "OMPLConversions.h"
-#include "OMPLSimplifer.h"
-#include "PlannerRegistry.h"
+#include <or_ompl/OMPLPlanner.h>
+#include <or_ompl/OMPLConversions.h>
+#include <or_ompl/OMPLSimplifer.h>
+#include <or_ompl/PlannerRegistry.h>
 
 using namespace OpenRAVE;
 

--- a/src/OMPLPlanner.cpp
+++ b/src/OMPLPlanner.cpp
@@ -41,10 +41,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ompl/base/StateSpaceTypes.h>
 #include <ompl/base/StateSpace.h>
 #include <ompl/base/spaces/RealVectorStateSpace.h>
-#include "OMPLConversions.h"
-#include "OMPLPlanner.h"
-#include "TSRGoal.h"
-#include "PlannerRegistry.h"
+#include <or_ompl/OMPLConversions.h>
+#include <or_ompl/OMPLPlanner.h>
+#include <or_ompl/TSRGoal.h>
+#include <or_ompl/PlannerRegistry.h>
 
 namespace or_ompl
 {

--- a/src/OMPLSimplifier.cpp
+++ b/src/OMPLSimplifier.cpp
@@ -32,8 +32,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <boost/make_shared.hpp>
 #include <ompl/base/ScopedState.h>
 #include <ompl/util/Time.h>
-#include "OMPLConversions.h"
-#include "OMPLSimplifer.h"
+#include <or_ompl/OMPLConversions.h>
+#include <or_ompl/OMPLSimplifer.h>
 
 using OpenRAVE::PA_None;
 using OpenRAVE::PA_Interrupt;

--- a/src/RobotStateSpace.cpp
+++ b/src/RobotStateSpace.cpp
@@ -1,4 +1,4 @@
-#include "RobotStateSpace.h"
+#include <or_ompl/RobotStateSpace.h>
 #include <openrave/openrave.h>
 
 using namespace or_ompl;

--- a/src/TSR.cpp
+++ b/src/TSR.cpp
@@ -1,4 +1,4 @@
-#include <TSR.h>
+#include <or_ompl/TSR.h>
 #include <Eigen/Geometry>
 #include <ompl/util/RandomNumbers.h>
 #include <vector>

--- a/src/TSRChain.cpp
+++ b/src/TSRChain.cpp
@@ -1,4 +1,4 @@
-#include <TSRChain.h>
+#include <or_ompl/TSRChain.h>
 
 #include <limits>
 #include <vector>

--- a/src/TSRGoal.cpp
+++ b/src/TSRGoal.cpp
@@ -1,5 +1,5 @@
-#include "TSRGoal.h"
-#include "RobotStateSpace.h"
+#include <or_ompl/TSRGoal.h>
+#include <or_ompl/RobotStateSpace.h>
 
 #include <boost/foreach.hpp>
 #include <ompl/base/spaces/RealVectorStateSpace.h>

--- a/src/TSRRobot.cpp
+++ b/src/TSRRobot.cpp
@@ -1,5 +1,5 @@
-#include "TSRRobot.h"
-#include "or_conversions.h"
+#include <or_ompl/TSRRobot.h>
+#include <or_ompl/or_conversions.h>
 #include <boost/make_shared.hpp>
 
 using namespace or_ompl;


### PR DESCRIPTION
Newer versions of OpenRAVE added an `int options` argument to the `Planner::PlannerParameters::serialize()` member function, which caused the attempted overrides in `OMPLPlannerParameters` and `OMPLHolonomicPlannerParameters` (which did not have the correct function signature) to not be called on copy.  This was causing bugs in parameter loading from `pr-constraint`.  This PR includes a configure-time check to see which to use.

This PR also renames the processing flag to be clearly specific to the derived class, to not confuse it with the similar flag in the base class.