### PR TITLE
Fix calculation of OMPL's longest valid segment length

### DIFF
--- a/src/OMPLConversions.cpp
+++ b/src/OMPLConversions.cpp
@@ -153,16 +153,9 @@ RobotStateSpacePtr CreateStateSpace(OpenRAVE::RobotBasePtr const robot,
 
     double conservative_resolution = std::numeric_limits<double>::max();
     for (size_t i = 0; i < num_dof; ++i) {
-        if (upperLimits[i] > lowerLimits[i]) {
-            conservative_resolution = std::min(conservative_resolution, dof_resolutions[i]);
-        }
+        conservative_resolution = std::min(conservative_resolution, dof_resolutions[i]);
     }
-    
-    if (std::isinf(conservative_resolution)) {
-        RAVELOG_ERROR("All joints have equal lower and upper limits.\n");
-        return RobotStateSpacePtr();
-    }
-    
+
     double conservative_fraction = conservative_resolution / state_space->getMaximumExtent();
     state_space->setLongestValidSegmentFraction(conservative_fraction);
     RAVELOG_DEBUG("Computed resolution of %f (%f fraction of extents).\n",

--- a/src/OMPLConversions.cpp
+++ b/src/OMPLConversions.cpp
@@ -142,32 +142,31 @@ RobotStateSpacePtr CreateStateSpace(OpenRAVE::RobotBasePtr const robot,
     state_space->setBounds(bounds);
 
     // Set the resolution at which OMPL should discretize edges for collision
-    // checking. OpenRAVE supports per-joint resolutions, so we compute one
-    // conservative value for all joints. We then convert this to a fraction
+    // checking. OpenRAVE supports per-joint resolutions, so we compute
+    // a conservative minimum resolution required across all joints.
+    // We then convert this to a fraction
     // of the workspace extents to call setLongestValidSegmentFraction.
     RAVELOG_DEBUG("Setting resolution.\n");
     std::vector<OpenRAVE::dReal> dof_resolutions;
     robot->GetActiveDOFResolutions(dof_resolutions);
     BOOST_ASSERT(dof_resolutions.size() == num_dof);
 
-    double conservative_fraction = std::numeric_limits<double>::max();
-    double longest_extent = 0;
+    double conservative_resolution = std::numeric_limits<double>::max();
     for (size_t i = 0; i < num_dof; ++i) {
         if (upperLimits[i] > lowerLimits[i]) {
-            double const joint_extents = upperLimits[i] - lowerLimits[i];
-            double const joint_fraction = dof_resolutions[i] / joint_extents;
-            conservative_fraction = std::min(conservative_fraction, joint_fraction);
-            longest_extent = std::max(longest_extent, joint_extents);
+            conservative_resolution = std::min(conservative_resolution, dof_resolutions[i]);
         }
     }
-
-    if (std::isinf(conservative_fraction)) {
+    
+    if (std::isinf(conservative_resolution)) {
         RAVELOG_ERROR("All joints have equal lower and upper limits.\n");
         return RobotStateSpacePtr();
     }
+    
+    double conservative_fraction = conservative_resolution / state_space->getMaximumExtent();
     state_space->setLongestValidSegmentFraction(conservative_fraction);
     RAVELOG_DEBUG("Computed resolution of %f (%f fraction of extents).\n",
-                  conservative_fraction * longest_extent, conservative_fraction);
+                  conservative_resolution, conservative_fraction);
 
     // Per-DOF weights are not supported by OMPL.
     // TODO: Emulate this by scaling joint values.


### PR DESCRIPTION
The current logic to calculate the `longest_valid_segment_fraction` parameter of an OMPL state space is based on an incorrect understanding of its meaning.  This parameter (length, equivalent to a collision checking resolution) is given as a fraction of the space's maximum extent (the largest possible distance between two states therein) [0].  For a `RealVectorStateSpace` (using the L2 norm), this is correctly computed as the diagonal Euclidean distance [1].  The current code seems to assume that the fraction is with respect to a particular joint's max range.

Here are the numbers for the current HERB model:
```
~lower  ~upper range res  ~j_frac
 0.5416 5.7416 5.20  0.02 0.00385
-1.96   1.96   3.92  0.02 0.00510
-2.73   2.73   5.46  0.02 0.00366
-0.86   3.13   3.99  0.02 0.00501
-4.79   1.3    6.09  0.02 0.00328
-1.56   1.56   3.12  0.02 0.00641
-2.99   2.99   5.98  0.02 0.00334
```

The `res` column is the DOF's OpenRAVE resolution parameter.  We don't currently set this to anything, so it gets its default value for all joints (0.02 is the hardcoded default during procedural construction [2] or loading from file [3]).  The `j_frac` column gives the `joint_fraction` value computed for each joint by the current code.  It then calculates:

```
conservative_fraction = 0.00328
longest_extent = 6.09
expected longest_valid_segment: 0.02 (as printed in the debug message)
longest_valid_segment_fraction set: 0.00328
actual longest_valid_segment: 0.04291 (due to maximum_extent value of 13.066)
```

The replacement code in the PR simply computes the minimum value of each joint's resolution parameter, and then sets the `longest_valid_segment_fraction` accordingly.  This will allow OMPL motions with an L2 norm up to the joint resolution of the finest joint.

As a result of fixing this bug, planning will be slower, since the collision checking resolution will be reduced from 0.04291 rad to 0.02 rad for HERB (although it won't be as bad as 2.1x slower because most planners use bisection testing).  We should also eventually consider two fixes which will alleviate this:

1. Setting a more reasonable joint resolution parameter when loading the HERB model (not sure what the appropriate field is in URDF for this)
2. Setting a custom distance metric on the OMPL state space to allow larger motions for joints with larger resolutions, so we no longer have to be conservative across joints.

Note that neither of these changes will help in isolation for `or_ompl` (although just fixing 1. will probably make CBiRRT significantly faster?)

[0] http://ompl.kavrakilab.org/StateSpace_8cpp_source.html#l00234
[1] http://ompl.kavrakilab.org/RealVectorStateSpace_8cpp_source.html#l00171
[2] https://github.com/rdiankov/openrave/blob/b3c0918cc46d9172a3137e2da4f9052ba4561979/src/libopenrave/kinbodyjoint.cpp#L30
[3] https://github.com/rdiankov/openrave/blob/b3c0918cc46d9172a3137e2da4f9052ba4561979/src/libopenrave-core/xmlreaders-core.cpp#L1582