### PR TITLE
Standardize formatting

### DIFF
--- a/include/or_ompl/OMPLConversions.h
+++ b/include/or_ompl/OMPLConversions.h
@@ -31,11 +31,14 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 *************************************************************************/
-#ifndef OMPLCONVERSIONS_H_
-#define OMPLCONVERSIONS_H_
+
+#ifndef OR_OMPL_OMPLCONVERSIONS_H_
+#define OR_OMPL_OMPLCONVERSIONS_H_
+
+#include <openrave/openrave.h>
 #include <ompl/util/Console.h>
 #include <ompl/geometric/PathGeometric.h>
-#include <openrave/openrave.h>
+
 #include <or_ompl/OMPLPlannerParameters.h>
 #include <or_ompl/StateSpaces.h>
 
@@ -56,6 +59,6 @@ OpenRAVE::PlannerStatus ToORTrajectory(OpenRAVE::RobotBasePtr const &robot,
                                        ompl::geometric::PathGeometric &ompl_traj,
                                        OpenRAVE::TrajectoryBasePtr or_traj);
 
-}
+} // namespace or_ompl
 
-#endif
+#endif // OR_OMPL_OMPLCONVERSIONS_H_

--- a/include/or_ompl/OMPLModule.h
+++ b/include/or_ompl/OMPLModule.h
@@ -1,3 +1,37 @@
+/***********************************************************************
+
+Copyright (c) 2014, Carnegie Mellon University
+All rights reserved.
+
+Authors: Michael Koval <mkoval@cs.cmu.edu>
+         Matthew Klingensmith <mklingen@cs.cmu.edu>
+         Christopher Dellin <cdellin@cs.cmu.edu>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+  Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*************************************************************************/
+
 /*
  * OMPLModule.h
  *
@@ -5,29 +39,29 @@
  *      Author: mklingen
  */
 
-#ifndef OMPLMODULE_H_
-#define OMPLMODULE_H_
+#ifndef OR_OMPL_OMPLMODULE_H_
+#define OR_OMPL_OMPLMODULE_H_
 
-#include <or_ompl/OMPLPlanner.h>
 #include <openrave/module.h>
 
-namespace or_ompl
-{
+#include <or_ompl/OMPLPlanner.h>
 
-    class OMPLModule: public OpenRAVE::ModuleBase
-    {
-        public:
-            OMPLModule(OpenRAVE::EnvironmentBasePtr penv);
-            virtual ~OMPLModule();
+namespace or_ompl {
 
-            bool SetRobot(std::ostream& output, std::istream& input);
-            bool Plan(std::ostream& output, std::istream& input);
+class OMPLModule: public OpenRAVE::ModuleBase {
+public:
+    OMPLModule(OpenRAVE::EnvironmentBasePtr penv);
+    virtual ~OMPLModule();
 
-        private:
-            OMPLPlannerPtr m_planner;
-            OpenRAVE::RobotBasePtr m_robot;
-            OMPLPlannerParametersPtr m_params;
-    };
+    bool SetRobot(std::ostream& output, std::istream& input);
+    bool Plan(std::ostream& output, std::istream& input);
 
-} /* namespace or_ompl */
-#endif /* OMPLMODULE_H_ */
+private:
+    OMPLPlannerPtr m_planner;
+    OpenRAVE::RobotBasePtr m_robot;
+    OMPLPlannerParametersPtr m_params;
+};
+
+} // namespace or_ompl
+
+#endif // OR_OMPL_OMPLMODULE_H_

--- a/include/or_ompl/OMPLPlanner.h
+++ b/include/or_ompl/OMPLPlanner.h
@@ -31,8 +31,9 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 *************************************************************************/
-#ifndef OMPLPLANNER_H
-#define OMPLPLANNER_H
+
+#ifndef OR_OMPL_OMPLPLANNER_H_
+#define OR_OMPL_OMPLPLANNER_H_
 
 #include <openrave-core.h>
 #include <openrave/planner.h>
@@ -42,8 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <or_ompl/StateSpaces.h>
 #include <or_ompl/OMPLPlannerParameters.h>
 
-namespace or_ompl
-{
+namespace or_ompl {
 
 typedef boost::function<ompl::base::Planner *(ompl::base::SpaceInformationPtr)> PlannerFactory;
 
@@ -59,8 +59,7 @@ public:
 
     virtual OpenRAVE::PlannerStatus PlanPath (OpenRAVE::TrajectoryBasePtr ptraj);
 
-    virtual PlannerParametersConstPtr GetParameters () const
-    {
+    virtual PlannerParametersConstPtr GetParameters () const {
         return m_parameters;
     }
     
@@ -68,8 +67,7 @@ public:
     bool GetParameterValCommand(std::ostream &sout, std::istream &sin) const;
 
 protected:
-    const ompl::base::PlannerPtr & get_planner()
-    {
+    const ompl::base::PlannerPtr & get_planner() {
         return m_planner;
     }
 
@@ -92,6 +90,6 @@ private:
 
 typedef boost::shared_ptr<OMPLPlanner> OMPLPlannerPtr;
 
-} /* namespace or_ompl */
+} // namespace or_ompl
 
-#endif /* OMPLPLANNER_H_ */
+#endif // OR_OMPL_OMPLPLANNER_H_

--- a/include/or_ompl/OMPLPlannerParameters.h
+++ b/include/or_ompl/OMPLPlannerParameters.h
@@ -31,18 +31,20 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 *************************************************************************/
-#ifndef CPARAMETERS_H
-#define CPARAMETERS_H
 
-#include <openrave-core.h>
-#include <openrave/planner.h>
+#ifndef OR_OMPL_OMPLPLANNERPARAMETERS_H_
+#define OR_OMPL_OMPLPLANNERPARAMETERS_H_
+
 #include <boost/foreach.hpp>
 #include <boost/make_shared.hpp>
+#include <openrave-core.h>
+#include <openrave/planner.h>
+
 #include <or_ompl/config.h>
 #include <or_ompl/TSRChain.h>
 
-namespace or_ompl
-{
+namespace or_ompl {
+
 class OMPLPlannerParameters : public OpenRAVE::PlannerBase::PlannerParameters
 {
 public:
@@ -51,8 +53,7 @@ public:
         , m_timeLimit(10)
         , m_isProcessingOMPL(false)
         , m_dat_filename("")
-        , m_trajs_fileformat("")
-    {
+        , m_trajs_fileformat("") {
         _vXMLParameters.push_back("seed");
         _vXMLParameters.push_back("time_limit");
         _vXMLParameters.push_back("dat_filename");
@@ -70,14 +71,12 @@ public:
 protected:
 
 #ifdef OR_OMPL_HAS_PPSEROPTS
-    virtual bool serialize(std::ostream& O, int options=0) const
-    {
+    virtual bool serialize(std::ostream& O, int options=0) const {
         if (!PlannerParameters::serialize(O, options)) {
             return false;
         }
 #else
-    virtual bool serialize(std::ostream& O) const
-    {
+    virtual bool serialize(std::ostream& O) const {
         if (!PlannerParameters::serialize(O)) {
             return false;
         }
@@ -95,8 +94,7 @@ protected:
     }
 
     ProcessElement startElement(std::string const &name,
-                                std::list<std::pair<std::string, std::string> > const &atts)
-    {
+                                std::list<std::pair<std::string, std::string> > const &atts) {
         if (m_isProcessingOMPL) {
             return PE_Ignore;
         }
@@ -120,8 +118,7 @@ protected:
         return m_isProcessingOMPL ? PE_Support : PE_Pass;
     }
 
-    virtual bool endElement(std::string const &name)
-    {
+    virtual bool endElement(std::string const &name) {
         if (m_isProcessingOMPL) {
             if (name == "seed") {
                 _ss >> m_seed;
@@ -151,6 +148,7 @@ protected:
 };
 
 typedef boost::shared_ptr<OMPLPlannerParameters> OMPLPlannerParametersPtr;
-}
 
-#endif
+} // namespace or_ompl
+
+#endif // OR_OMPL_OMPLPLANNERPARAMETERS_H_

--- a/include/or_ompl/OMPLSimplifer.h
+++ b/include/or_ompl/OMPLSimplifer.h
@@ -29,16 +29,17 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 *************************************************************************/
-#ifndef OMPLSIMPLIFIER_H
-#define OMPLSIMPLIFIER_H
+
+#ifndef OR_OMPL_OMPLSIMPLIFIER_H_
+#define OR_OMPL_OMPLSIMPLIFIER_H_
 
 #include <openrave-core.h>
 #include <openrave/planner.h>
 #include <ompl/geometric/PathSimplifier.h>
+
 #include <or_ompl/OMPLPlannerParameters.h>
 
-namespace or_ompl
-{
+namespace or_ompl {
 
 class OMPLSimplifier : public OpenRAVE::PlannerBase {
 public:
@@ -64,6 +65,6 @@ private:
 
 typedef boost::shared_ptr<OMPLSimplifier> OMPLSimplifierPtr;
 
-} /* namespace or_ompl */
+} // namespace or_ompl
 
-#endif /* OMPLPLANNER_H_ */
+#endif // OR_OMPL_OMPLSIMPLIFIER_H_

--- a/include/or_ompl/PlannerRegistry.h
+++ b/include/or_ompl/PlannerRegistry.h
@@ -29,8 +29,10 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 *************************************************************************/
-#ifndef PLANNERREGISTRY_H_
-#define PLANNERREGISTRY_H_
+
+#ifndef OR_OMPL_PLANNERREGISTRY_H_
+#define OR_OMPL_PLANNERREGISTRY_H_
+
 #include <string>
 #include <vector>
 #include <ompl/base/Planner.h>
@@ -44,6 +46,7 @@ std::vector<std::string> get_planner_names();
 ompl::base::Planner *create(std::string const &name,
                             ompl::base::SpaceInformationPtr space);
 
-}
-}
-#endif
+} // namespace registry
+} // namespace or_ompl
+
+#endif // OR_OMPL_PLANNERREGISTRY_H_

--- a/include/or_ompl/StateSpaces.h
+++ b/include/or_ompl/StateSpaces.h
@@ -1,110 +1,143 @@
-#ifndef OR_OMPL_STATE_SPACES_H_
-#define OR_OMPL_STATE_SPACES_H_
+/***********************************************************************
 
+Copyright (c) 2014, Carnegie Mellon University
+All rights reserved.
+
+Authors: Michael Koval <mkoval@cs.cmu.edu>
+         Matthew Klingensmith <mklingen@cs.cmu.edu>
+         Christopher Dellin <cdellin@cs.cmu.edu>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+  Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*************************************************************************/
+
+#ifndef OR_OMPL_STATESPACES_H_
+#define OR_OMPL_STATESPACES_H_
+
+#include <boost/shared_ptr.hpp>
+#include <boost/weak_ptr.hpp>
+#include <openrave/openrave.h>
 #include <ompl/base/StateSpace.h>
 #include <ompl/base/spaces/SO2StateSpace.h>
 #include <ompl/base/spaces/RealVectorStateSpace.h>
 #include <ompl/base/StateValidityChecker.h>
-#include <openrave/openrave.h>
-#include <boost/shared_ptr.hpp>
-#include <boost/weak_ptr.hpp>
 
 namespace or_ompl {
-    
+
+/**
+ * Implements a state space for an OpenRAVE robot
+ */
+class ContinuousJointsStateSpace : public ompl::base::CompoundStateSpace {
+
+public:
     /**
-     * Implements a state space for an OpenRAVE robot
+     * Constructor
+     * @param dof_indices An ordered list of indices this state corresponds to
      */
-    class ContinuousJointsStateSpace : public ompl::base::CompoundStateSpace {
+    ContinuousJointsStateSpace(const std::vector<bool>& is_continuous);
 
-
-    public:
-        /**
-         * Constructor
-         * @param dof_indices An ordered list of indices this state corresponds to
-         */
-        ContinuousJointsStateSpace(const std::vector<bool>& is_continuous);
-
-        /** \brief Register the projections for this state space. Usually, this is at least the default
-            projection. These are implicit projections, set by the implementation of the state space. This is called by setup(). */
-        virtual void registerProjections();
-
-        /**
-         * Set the upper/lower bounds of the state space.
-         */
-        void setBounds(const ompl::base::RealVectorBounds& bounds);
-
-    private:
-        std::vector<bool> _isContinuous;
-        ompl::base::ProjectionEvaluatorPtr _projectionEvaluator;
-
-    };
-
-    typedef boost::shared_ptr<ContinuousJointsStateSpace> ContinuousJointsStateSpacePtr;
-
-    class ContinuousJointsProjectionEvaluator : public ompl::base::ProjectionEvaluator {
-        public:
-            ContinuousJointsProjectionEvaluator(ompl::base::StateSpace* stateSpace);
-            ContinuousJointsProjectionEvaluator(ompl::base::StateSpacePtr stateSpace);
-            virtual ~ContinuousJointsProjectionEvaluator();
-
-            /** \brief Return the dimension of the projection defined by this evaluator */
-            virtual unsigned int getDimension() const;
-
-            /** \brief Compute the projection as an array of double values */
-            virtual void project(const ompl::base::State *state, ompl::base::EuclideanProjection &projection) const;
-
-            virtual void defaultCellSizes();
-
-            virtual void setup();
-        protected:
-            or_ompl::ContinuousJointsStateSpace* _robotStateSpace;
-            ompl::base::ProjectionMatrix _projectionMatrix;
-    };
-
-    typedef boost::shared_ptr<ContinuousJointsProjectionEvaluator> ContinuousJointsProjectionEvaluatorPtr;
+    /** \brief Register the projections for this state space. Usually, this is at least the default
+        projection. These are implicit projections, set by the implementation of the state space. This is called by setup(). */
+    virtual void registerProjections();
 
     /**
-     * This is like ompl::base::StateValidityChecker,
-     * except it also knows how to compute forward kinematics
-     * to match the state
-     * 
-     * this should work for general state spaces (e.g. CompoundStateSpaces)
+     * Set the upper/lower bounds of the state space.
      */
-    class OrStateValidityChecker: public ompl::base::StateValidityChecker
-    {
+    void setBounds(const ompl::base::RealVectorBounds& bounds);
+
+private:
+    std::vector<bool> _isContinuous;
+    ompl::base::ProjectionEvaluatorPtr _projectionEvaluator;
+
+};
+
+typedef boost::shared_ptr<ContinuousJointsStateSpace> ContinuousJointsStateSpacePtr;
+
+class ContinuousJointsProjectionEvaluator : public ompl::base::ProjectionEvaluator {
     public:
-        OrStateValidityChecker(const ompl::base::SpaceInformationPtr &si,
-            OpenRAVE::RobotBasePtr robot, std::vector<int> const &indices);
-        virtual bool computeFk(const ompl::base::State *state, uint32_t checklimits) const;
-        virtual bool isValid(const ompl::base::State *state) const;
-        void resetStatistics() { m_numCollisionChecks = 0; m_totalCollisionTime = 0.0; }
-        int getNumCollisionChecks() { return m_numCollisionChecks; }
-        double getTotalCollisionTime() { return m_totalCollisionTime; }
-        const std::vector<int> & getIndices() { return m_indices; }
+        ContinuousJointsProjectionEvaluator(ompl::base::StateSpace* stateSpace);
+        ContinuousJointsProjectionEvaluator(ompl::base::StateSpacePtr stateSpace);
+        virtual ~ContinuousJointsProjectionEvaluator();
+
+        /** \brief Return the dimension of the projection defined by this evaluator */
+        virtual unsigned int getDimension() const;
+
+        /** \brief Compute the projection as an array of double values */
+        virtual void project(const ompl::base::State *state, ompl::base::EuclideanProjection &projection) const;
+
+        virtual void defaultCellSizes();
+
+        virtual void setup();
     protected:
-        ompl::base::StateSpace * m_stateSpace;
-        OpenRAVE::EnvironmentBasePtr m_env;
-        OpenRAVE::RobotBasePtr m_robot;
-        std::vector<int> const m_indices;
-        mutable int m_numCollisionChecks;
-        mutable double m_totalCollisionTime;
-    };
+        or_ompl::ContinuousJointsStateSpace* _robotStateSpace;
+        ompl::base::ProjectionMatrix _projectionMatrix;
+};
 
-    typedef boost::shared_ptr<OrStateValidityChecker> OrStateValidityCheckerPtr;
+typedef boost::shared_ptr<ContinuousJointsProjectionEvaluator> ContinuousJointsProjectionEvaluatorPtr;
 
-    /**
-     * StateRobotSetter for RealVectorStateSpaces
-     */
-    class RealVectorOrStateValidityChecker: public OrStateValidityChecker
-    {
-    public:
-        RealVectorOrStateValidityChecker(const ompl::base::SpaceInformationPtr &si,
-            OpenRAVE::RobotBasePtr robot, std::vector<int> const &indices);
-        virtual bool computeFk(const ompl::base::State *state, uint32_t checklimits) const;
-    private:
-        const std::size_t m_num_dof;
-    };
+/**
+ * This is like ompl::base::StateValidityChecker,
+ * except it also knows how to compute forward kinematics
+ * to match the state
+ * 
+ * this should work for general state spaces (e.g. CompoundStateSpaces)
+ */
+class OrStateValidityChecker: public ompl::base::StateValidityChecker
+{
+public:
+    OrStateValidityChecker(const ompl::base::SpaceInformationPtr &si,
+        OpenRAVE::RobotBasePtr robot, std::vector<int> const &indices);
+    virtual bool computeFk(const ompl::base::State *state, uint32_t checklimits) const;
+    virtual bool isValid(const ompl::base::State *state) const;
+    void resetStatistics() { m_numCollisionChecks = 0; m_totalCollisionTime = 0.0; }
+    int getNumCollisionChecks() { return m_numCollisionChecks; }
+    double getTotalCollisionTime() { return m_totalCollisionTime; }
+    const std::vector<int> & getIndices() { return m_indices; }
+protected:
+    ompl::base::StateSpace * m_stateSpace;
+    OpenRAVE::EnvironmentBasePtr m_env;
+    OpenRAVE::RobotBasePtr m_robot;
+    std::vector<int> const m_indices;
+    mutable int m_numCollisionChecks;
+    mutable double m_totalCollisionTime;
+};
 
-}
+typedef boost::shared_ptr<OrStateValidityChecker> OrStateValidityCheckerPtr;
 
-#endif
+/**
+ * StateRobotSetter for RealVectorStateSpaces
+ */
+class RealVectorOrStateValidityChecker: public OrStateValidityChecker
+{
+public:
+    RealVectorOrStateValidityChecker(const ompl::base::SpaceInformationPtr &si,
+        OpenRAVE::RobotBasePtr robot, std::vector<int> const &indices);
+    virtual bool computeFk(const ompl::base::State *state, uint32_t checklimits) const;
+private:
+    const std::size_t m_num_dof;
+};
+
+} // namespace or_ompl
+
+#endif // OR_OMPL_STATESPACES_H_

--- a/include/or_ompl/TSR.h
+++ b/include/or_ompl/TSR.h
@@ -1,102 +1,135 @@
-#ifndef OMPL_TSR_H_
-#define OMPL_TSR_H_
+/***********************************************************************
 
-#include <Eigen/Dense>
+Copyright (c) 2014, Carnegie Mellon University
+All rights reserved.
+
+Authors: Jennifer King <jeking04@gmail.com>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+  Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*************************************************************************/
+
+#ifndef OR_OMPL_TSR_H_
+#define OR_OMPL_TSR_H_
+
 #include <boost/shared_ptr.hpp>
+#include <Eigen/Dense>
 
 namespace or_ompl {
-	class TSR {
+        
+class TSR {
 
-	public: 
-		typedef boost::shared_ptr<TSR> Ptr;
+public: 
+    typedef boost::shared_ptr<TSR> Ptr;
 
-		/**
-		 * Constructor
-		 */
-		TSR();
+    /**
+     * Constructor
+     */
+    TSR();
 
-		/**
-		 * Constructor
-		 *
-		 * @param T0_w Transform from world frame to the TSR frame w
-		 * @param Tw_e End-effector offset transform in the coordinates of w
-		 * @param Bw 6x2 matrix of bounds in the coordinates of w
-		 *   bounds are (x, y, z, roll, pitch, yaw - assume RPY Euler angle convention)
-		 */
-		TSR(const Eigen::Affine3d &T0_w,
-			const Eigen::Affine3d &Tw_e,
-			const Eigen::Matrix<double, 6, 2> &Bw);
+    /**
+     * Constructor
+     *
+     * @param T0_w Transform from world frame to the TSR frame w
+     * @param Tw_e End-effector offset transform in the coordinates of w
+     * @param Bw 6x2 matrix of bounds in the coordinates of w
+     *   bounds are (x, y, z, roll, pitch, yaw - assume RPY Euler angle convention)
+     */
+    TSR(const Eigen::Affine3d &T0_w,
+        const Eigen::Affine3d &Tw_e,
+        const Eigen::Matrix<double, 6, 2> &Bw);
 
-		/**
-		 * Deserialize a serialized TSR.  
-		 *  
-		 * @param ss The stream to read the serialized TSR from
-		 */
-		bool deserialize(std::stringstream &ss);
+    /**
+     * Deserialize a serialized TSR.  
+     *  
+     * @param ss The stream to read the serialized TSR from
+     */
+    bool deserialize(std::stringstream &ss);
 
-		/**
-		 * Compute the distance to the TSR
-		 *
-		 * @param ee_pose The pose of the end-effector in world frame
-		 */
-		Eigen::Matrix<double, 6, 1> distance(const Eigen::Affine3d &ee_pose) const;
+    /**
+     * Compute the distance to the TSR
+     *
+     * @param ee_pose The pose of the end-effector in world frame
+     */
+    Eigen::Matrix<double, 6, 1> distance(const Eigen::Affine3d &ee_pose) const;
 
-		/**
-		 * Compute the displacement to the TSR
-		 * 
-		 * @param ee_pose The pose of the end-effector in world frame
-		 */
-		Eigen::Matrix<double, 6, 1> displacement(const Eigen::Affine3d &ee_pose) const;
+    /**
+     * Compute the displacement to the TSR
+     * 
+     * @param ee_pose The pose of the end-effector in world frame
+     */
+    Eigen::Matrix<double, 6, 1> displacement(const Eigen::Affine3d &ee_pose) const;
 
-		/**
-		 * Sample a pose from the TSR
-		 *
-		 * @return The sampled pose
-		 */
-		Eigen::Affine3d sample(void) const;
-			
-		/**
-		 * Sample a displacement transform from the TSR
-		 * @return The sampled transform
-		 */
-		Eigen::Affine3d sampleDisplacementTransform(void) const;
+    /**
+     * Sample a pose from the TSR
+     *
+     * @return The sampled pose
+     */
+    Eigen::Affine3d sample(void) const;
+        
+    /**
+     * Sample a displacement transform from the TSR
+     * @return The sampled transform
+     */
+    Eigen::Affine3d sampleDisplacementTransform(void) const;
 
-		/**
-		 * @return The transform for the frame of the TSR (T0_w)
-		 */
-		Eigen::Affine3d getOriginTransform(void) const { return _T0_w; }
+    /**
+     * @return The transform for the frame of the TSR (T0_w)
+     */
+    Eigen::Affine3d getOriginTransform(void) const { return _T0_w; }
 
-		/**
-		 * @return The end-effector offset transform (Tw_e)
-		 */
-		Eigen::Affine3d getEndEffectorOffsetTransform(void) const { return _Tw_e; }
+    /**
+     * @return The end-effector offset transform (Tw_e)
+     */
+    Eigen::Affine3d getEndEffectorOffsetTransform(void) const { return _Tw_e; }
 
-		/**
-		 * @return The bounds specified for the TSR (Bw)
-		 */
-		Eigen::Matrix<double, 6, 2> getBounds(void) const { return _Bw; }
-		
-		/**
-		 * Output operator
-		 */
-		friend std::ostream& operator << (std::ostream &out, const TSR &tsr){
-			out << "TSR: " << std::endl;
-			out << "\tT0_w: " << tsr._T0_w.matrix() << std::endl;
-			out << "\tTw_e: " << tsr._Tw_e.matrix() << std::endl;
-			out << "\tBw: " << tsr._Bw << std::endl;
+    /**
+     * @return The bounds specified for the TSR (Bw)
+     */
+    Eigen::Matrix<double, 6, 2> getBounds(void) const { return _Bw; }
+    
+    /**
+     * Output operator
+     */
+    friend std::ostream& operator << (std::ostream &out, const TSR &tsr) {
+        out << "TSR: " << std::endl;
+        out << "\tT0_w: " << tsr._T0_w.matrix() << std::endl;
+        out << "\tTw_e: " << tsr._Tw_e.matrix() << std::endl;
+        out << "\tBw: " << tsr._Bw << std::endl;
 
-			return out;
-		}
+        return out;
+    }
 
-	protected:
-		Eigen::Affine3d _T0_w;
-		Eigen::Affine3d _T0_w_inv;
-		Eigen::Affine3d _Tw_e;
-		Eigen::Affine3d _Tw_e_inv;
-		Eigen::Matrix<double, 6, 2> _Bw;
-		bool _initialized;
-	};
-	   
-}
+protected:
+    Eigen::Affine3d _T0_w;
+    Eigen::Affine3d _T0_w_inv;
+    Eigen::Affine3d _Tw_e;
+    Eigen::Affine3d _Tw_e_inv;
+    Eigen::Matrix<double, 6, 2> _Bw;
+    bool _initialized;
+};
+       
+} // namespace or_ompl
 
-#endif
+#endif // OR_OMPL_TSR_H_

--- a/include/or_ompl/TSRChain.h
+++ b/include/or_ompl/TSRChain.h
@@ -1,93 +1,126 @@
-#ifndef OMPL_TSR_CHAIN_H_
-#define OMPL_TSR_CHAIN_H_
+/***********************************************************************
 
-#include <or_ompl/TSR.h>
-#include <or_ompl/TSRRobot.h>
+Copyright (c) 2014, Carnegie Mellon University
+All rights reserved.
+
+Authors: Jennifer King <jeking04@gmail.com>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+  Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*************************************************************************/
+
+#ifndef OR_OMPL_TSRCHAIN_H_
+#define OR_OMPL_TSRCHAIN_H_
 
 #include <vector>
 #include <boost/shared_ptr.hpp>
 #include <openrave/openrave.h>
 
+#include <or_ompl/TSR.h>
+#include <or_ompl/TSRRobot.h>
+
 namespace or_ompl {
-	class TSRChain {
 
-	public:
-		typedef boost::shared_ptr<TSRChain> Ptr;
+class TSRChain {
 
-		/**
-		 * Constructor
-		 */
-		TSRChain();
-		
-		/**
-		 * Constructor
-		 *
-		 * @param sample_start True if the chain should be used to sample the start configuration
-		 * @param sample_goal True if the chain should be used to sample the start configuration
-		 * @param constrain True if the chain should be applied trajectory wide
-		 * @param tsrs The list of TSRs in the chain
-		 */
-		TSRChain(const bool &sample_start, 
-				 const bool &sample_goal, 
-				 const bool &constrain,
-				 const std::vector<TSR::Ptr> &tsrs);
+public:
+    typedef boost::shared_ptr<TSRChain> Ptr;
 
-		/**
-		 * Deserialize a serialized TSR Chain.  
-		 *  
-		 * @param ss The stream to read the serialized TSR from
-		 */
-		bool deserialize(std::stringstream &ss);
+    /**
+     * Constructor
+     */
+    TSRChain();
+    
+    /**
+     * Constructor
+     *
+     * @param sample_start True if the chain should be used to sample the start configuration
+     * @param sample_goal True if the chain should be used to sample the start configuration
+     * @param constrain True if the chain should be applied trajectory wide
+     * @param tsrs The list of TSRs in the chain
+     */
+    TSRChain(const bool &sample_start, 
+             const bool &sample_goal, 
+             const bool &constrain,
+             const std::vector<TSR::Ptr> &tsrs);
 
-		/**
-		 * @return True if this chain should be used to sample a start
-		 */
-		bool sampleStart() const { return _sample_start; }
+    /**
+     * Deserialize a serialized TSR Chain.  
+     *  
+     * @param ss The stream to read the serialized TSR from
+     */
+    bool deserialize(std::stringstream &ss);
 
-		/**
-		 * @return True if this chain should be used to sample a goal
-		 */
-		bool sampleGoal() const { return _sample_goal; }
+    /**
+     * @return True if this chain should be used to sample a start
+     */
+    bool sampleStart() const { return _sample_start; }
 
-		/**
-		 * @return True if this chain should be applied as a trajectory wide constraint
-		 */
-		bool isTrajectoryConstraint() const { return _constrain; }
-		
+    /**
+     * @return True if this chain should be used to sample a goal
+     */
+    bool sampleGoal() const { return _sample_goal; }
 
-		/**
-		 * @return The list of TSRs that make up this chain
-		 */
-		std::vector<TSR::Ptr> getTSRs() const { return _tsrs; }
+    /**
+     * @return True if this chain should be applied as a trajectory wide constraint
+     */
+    bool isTrajectoryConstraint() const { return _constrain; }
+    
 
-		/**
-		 * @return A sample from the TSR chain
-		 */
-		Eigen::Affine3d sample(void) const;
+    /**
+     * @return The list of TSRs that make up this chain
+     */
+    std::vector<TSR::Ptr> getTSRs() const { return _tsrs; }
 
-		/**
-		 * Compute the distance to the TSR
-		 *
-		 * @param ee_pose The pose of the end-effector in world frame
-		 */
-		Eigen::Matrix<double, 6, 1> distance(const Eigen::Affine3d &ee_pose) const;
+    /**
+     * @return A sample from the TSR chain
+     */
+    Eigen::Affine3d sample(void) const;
 
-        /**
-         * Set the planning environment. This is required to enable computing
-         * distance to a TSR.
-         * @param penv The OpenRAVE environment this TSRChain will be used in
-         */
-        void setEnv(const OpenRAVE::EnvironmentBasePtr &penv);
+    /**
+     * Compute the distance to the TSR
+     *
+     * @param ee_pose The pose of the end-effector in world frame
+     */
+    Eigen::Matrix<double, 6, 1> distance(const Eigen::Affine3d &ee_pose) const;
 
-	private:
-		bool _initialized;
-		bool _sample_start;
-		bool _sample_goal;
-		bool _constrain;
-		std::vector<TSR::Ptr> _tsrs;
-        TSRRobot::Ptr _tsr_robot;
-	};
-	   
-}
+    /**
+     * Set the planning environment. This is required to enable computing
+     * distance to a TSR.
+     * @param penv The OpenRAVE environment this TSRChain will be used in
+     */
+    void setEnv(const OpenRAVE::EnvironmentBasePtr &penv);
 
-#endif
+private:
+    bool _initialized;
+    bool _sample_start;
+    bool _sample_goal;
+    bool _constrain;
+    std::vector<TSR::Ptr> _tsrs;
+    TSRRobot::Ptr _tsr_robot;
+};
+       
+} // namespace or_ompl
+
+#endif // OR_OMPL_TSRCHAIN_H_

--- a/include/or_ompl/TSRGoal.h
+++ b/include/or_ompl/TSRGoal.h
@@ -1,100 +1,133 @@
-#ifndef TSR_GOAL_H_
-#define TSR_GOAL_H_
+/***********************************************************************
 
-#include <or_ompl/TSR.h>
-#include <or_ompl/TSRChain.h>
+Copyright (c) 2014, Carnegie Mellon University
+All rights reserved.
+
+Authors: Jennifer King <jeking04@gmail.com>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+  Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*************************************************************************/
+
+#ifndef OR_OMPL_TSRGOAL_H_
+#define OR_OMPL_TSRGOAL_H_
+
+#include <boost/make_shared.hpp>
 #include <openrave-core.h>
 #include <ompl/base/goals/GoalSampleableRegion.h>
 #include <ompl/base/SpaceInformation.h>
 #include <ompl/base/State.h>
 
-
-#include <boost/make_shared.hpp>
+#include <or_ompl/TSR.h>
+#include <or_ompl/TSRChain.h>
 
 namespace or_ompl {
-	/**
-	 * Implements a goal region defined by a center goal position and a radius
-	 */
-	class TSRGoal : public ompl::base::GoalSampleableRegion {
 
-	public:
-		typedef boost::shared_ptr<TSRGoal> Ptr;
+/**
+ * Implements a goal region defined by a center goal position and a radius
+ */
+class TSRGoal : public ompl::base::GoalSampleableRegion {
 
-		/**
-		 * Constructor
-		 *
-		 * @param si The space information object describing the space where the algorithm will be used
-		 * @param tsr The TSR chain describe the goal region
-		 * @param robot The robot to sample a pose for
-		 */
-		TSRGoal(const ompl::base::SpaceInformationPtr &si,
-				const TSR::Ptr &tsr,
-				OpenRAVE::RobotBasePtr robot,
-				OrStateValidityCheckerPtr or_validity_checker);
+public:
+    typedef boost::shared_ptr<TSRGoal> Ptr;
 
-		/**
-		 * Constructor
-		 *
-		 * @param si The space information object describing the space where the algorithm will be used
-		 * @param tsrchain The TSR chain describe the goal region
-		 * @param robot The robot to sample a pose for
-		 */
-		TSRGoal(const ompl::base::SpaceInformationPtr &si,
-				const TSRChain::Ptr &tsrchain,
-				OpenRAVE::RobotBasePtr robot,
-				OrStateValidityCheckerPtr or_validity_checker);
+    /**
+     * Constructor
+     *
+     * @param si The space information object describing the space where the algorithm will be used
+     * @param tsr The TSR chain describe the goal region
+     * @param robot The robot to sample a pose for
+     */
+    TSRGoal(const ompl::base::SpaceInformationPtr &si,
+            const TSR::Ptr &tsr,
+            OpenRAVE::RobotBasePtr robot,
+            OrStateValidityCheckerPtr or_validity_checker);
 
-		/**
-		 * Constructor
-		 *
-		 * @param si The space information object describing the space where the algorithm will be used
-		 * @param tsrchains The list of TSR chain describe the goal region
-		 * @param robot The robot to sample a pose for
-		 */
-		TSRGoal(const ompl::base::SpaceInformationPtr &si,
-				const std::vector<TSRChain::Ptr> &tsrchains,
-				OpenRAVE::RobotBasePtr robot,
-				OrStateValidityCheckerPtr or_validity_checker);
+    /**
+     * Constructor
+     *
+     * @param si The space information object describing the space where the algorithm will be used
+     * @param tsrchain The TSR chain describe the goal region
+     * @param robot The robot to sample a pose for
+     */
+    TSRGoal(const ompl::base::SpaceInformationPtr &si,
+            const TSRChain::Ptr &tsrchain,
+            OpenRAVE::RobotBasePtr robot,
+            OrStateValidityCheckerPtr or_validity_checker);
 
-		/**
-		 * Destructor
-		 */
-		~TSRGoal();
-            
-		/**
-		 * Determines if the given state falls within the goal radius
-		 *
-		 * @param state The state to check
-		 * @return True if the state is within the goal radius
-		 */
-		virtual bool isSatisfied(const ompl::base::State *state) const;
-            
-		/**
-		 * Calculates the distance between the state and the edge of the goal region
-		 *
-		 * @param state The state
-		 * @return The distance to the edge of the goal region (0 if the state is within the goal region)
-		 */
-		virtual double distanceGoal(const ompl::base::State *state) const;
-            
-		/**
-		 * Samples a state from within the goal region
-		 *
-		 * @param state The sampled state
-		 */
-		virtual void sampleGoal(ompl::base::State *state) const;
+    /**
+     * Constructor
+     *
+     * @param si The space information object describing the space where the algorithm will be used
+     * @param tsrchains The list of TSR chain describe the goal region
+     * @param robot The robot to sample a pose for
+     */
+    TSRGoal(const ompl::base::SpaceInformationPtr &si,
+            const std::vector<TSRChain::Ptr> &tsrchains,
+            OpenRAVE::RobotBasePtr robot,
+            OrStateValidityCheckerPtr or_validity_checker);
 
-		/**
-		 * @return max int
-		 */
-		virtual unsigned int maxSampleCount() const;
-            
-	private:
-		std::vector<TSRChain::Ptr> _tsr_chains;
-		OpenRAVE::RobotBasePtr _robot;
-		ompl::base::StateSpace * _state_space;
-		OrStateValidityCheckerPtr _or_validity_checker;
-	};
+    /**
+     * Destructor
+     */
+    ~TSRGoal();
+        
+    /**
+     * Determines if the given state falls within the goal radius
+     *
+     * @param state The state to check
+     * @return True if the state is within the goal radius
+     */
+    virtual bool isSatisfied(const ompl::base::State *state) const;
+        
+    /**
+     * Calculates the distance between the state and the edge of the goal region
+     *
+     * @param state The state
+     * @return The distance to the edge of the goal region (0 if the state is within the goal region)
+     */
+    virtual double distanceGoal(const ompl::base::State *state) const;
+        
+    /**
+     * Samples a state from within the goal region
+     *
+     * @param state The sampled state
+     */
+    virtual void sampleGoal(ompl::base::State *state) const;
+
+    /**
+     * @return max int
+     */
+    virtual unsigned int maxSampleCount() const;
+        
+private:
+    std::vector<TSRChain::Ptr> _tsr_chains;
+    OpenRAVE::RobotBasePtr _robot;
+    ompl::base::StateSpace * _state_space;
+    OrStateValidityCheckerPtr _or_validity_checker;
+};
       
-}
-#endif
+} // namespace or_ompl
+
+#endif // OR_OMPL_TSRGOAL_H_

--- a/include/or_ompl/TSRRobot.h
+++ b/include/or_ompl/TSRRobot.h
@@ -1,64 +1,98 @@
-#ifndef OMPL_TSR_ROBOT_H_
-#define OMPL_TSR_ROBOT_H_
+/***********************************************************************
+
+Copyright (c) 2014, Carnegie Mellon University
+All rights reserved.
+
+Authors: Jennifer King <jeking04@gmail.com>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+  Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*************************************************************************/
+
+#ifndef OR_OMPL_TSRROBOT_H_
+#define OR_OMPL_TSRROBOT_H_
+
+#include <boost/shared_ptr.hpp>
+#include <openrave/openrave.h>
 
 #include <or_ompl/TSR.h>
-#include <openrave/openrave.h>
-#include <boost/shared_ptr.hpp>
 
 namespace or_ompl {
 
+/**
+ * Decorator for an OpenRAVE Robot constructed to represent
+ * a TSR chain
+ */
+class TSRRobot {
+    
+public:
+
     /**
-     * Decorator for an OpenRAVE Robot constructed to represent
-     * a TSR chain
+     * Expose a shared ptr for the robot
      */
-    class TSRRobot {
-        
-    public:
+    typedef boost::shared_ptr<TSRRobot> Ptr;
+    
+    /**
+     * Constructor
+     */
+    TSRRobot(const std::vector<TSR::Ptr> &tsrs, const OpenRAVE::EnvironmentBasePtr &penv);
 
-        /**
-         * Expose a shared ptr for the robot
-         */
-        typedef boost::shared_ptr<TSRRobot> Ptr;
-        
-        /**
-         * Constructor
-         */
-        TSRRobot(const std::vector<TSR::Ptr> &tsrs, const OpenRAVE::EnvironmentBasePtr &penv);
+    /**
+     * @return True if the construction was successful, false otherwise
+     */
+    bool construct();
 
-        /**
-         * @return True if the construction was successful, false otherwise
-         */
-        bool construct();
+    /**
+     * Finds the nearest reachable end-effector transform to the given transform
+     * @param Ttarget - The target end-effector transform
+     */
+    Eigen::Affine3d findNearestFeasibleTransform(const Eigen::Affine3d &Ttarget);
 
-        /**
-         * Finds the nearest reachable end-effector transform to the given transform
-         * @param Ttarget - The target end-effector transform
-         */
-        Eigen::Affine3d findNearestFeasibleTransform(const Eigen::Affine3d &Ttarget);
+    /**
+     * @return True if this is a point TSR chain - meaning no TSRs have any freedom in the Bw matrix
+     */
+    bool isPointRobot() const { return _point_tsr; }
 
-        /**
-         * @return True if this is a point TSR chain - meaning no TSRs have any freedom in the Bw matrix
-         */
-        bool isPointRobot() const { return _point_tsr; }
+    /**
+     * @return True if robot has been properly initialized, false otherwise
+     */
+    bool isInitialized() const { return _initialized; }
 
-        /**
-         * @return True if robot has been properly initialized, false otherwise
-         */
-        bool isInitialized() const { return _initialized; }
+private:
 
-    private:
+    std::vector<TSR::Ptr> _tsrs;
+    OpenRAVE::EnvironmentBasePtr  _penv;
+    OpenRAVE::RobotBasePtr _probot;
+    std::string _solver;
+    OpenRAVE::IkSolverBasePtr _ik_solver;
+    std::vector<OpenRAVE::dReal> _upperlimits;
+    std::vector<OpenRAVE::dReal> _lowerlimits;
+    bool _initialized;
+    bool _point_tsr;
+    unsigned int _num_dof;
+};
 
-        std::vector<TSR::Ptr> _tsrs;
-        OpenRAVE::EnvironmentBasePtr  _penv;
-        OpenRAVE::RobotBasePtr _probot;
-        std::string _solver;
-        OpenRAVE::IkSolverBasePtr _ik_solver;
-        std::vector<OpenRAVE::dReal> _upperlimits;
-        std::vector<OpenRAVE::dReal> _lowerlimits;
-        bool _initialized;
-        bool _point_tsr;
-        unsigned int _num_dof;
-    };
-}
+} // namespace or_ompl
 
-#endif
+#endif // OR_OMPL_TSRROBOT_H_

--- a/include/or_ompl/or_conversions.h
+++ b/include/or_ompl/or_conversions.h
@@ -1,56 +1,86 @@
-#ifndef OR_CONVERSIONS_
-#define OR_CONVERSIONS_
+/***********************************************************************
+
+Copyright (c) 2014, Carnegie Mellon University
+All rights reserved.
+
+Authors: Michael Koval <mkoval@cs.cmu.edu>
+         Matthew Klingensmith <mklingen@cs.cmu.edu>
+         Christopher Dellin <cdellin@cs.cmu.edu>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+  Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*************************************************************************/
+
+#ifndef OR_OMPL_OR_CONVERSIONS_H_
+#define OR_OMPL_OR_CONVERSIONS_H_
 
 namespace or_ompl {
 
-    inline Eigen::Vector3d toEigen3(OpenRAVE::Vector const &or_v)
-    {
-        Eigen::Vector3d eigen_v;
-        eigen_v << or_v.x, or_v.y, or_v.z;
-        return eigen_v;
-    }
-
-    inline Eigen::Affine3d toEigen(OpenRAVE::Transform const &or_tf)
-    {
-        OpenRAVE::TransformMatrix or_matrix(or_tf);
-        Eigen::Affine3d eigen_tf = Eigen::Affine3d::Identity();
-        eigen_tf.linear() << or_matrix.m[0], or_matrix.m[1], or_matrix.m[2],
-            or_matrix.m[4], or_matrix.m[5], or_matrix.m[6],
-            or_matrix.m[8], or_matrix.m[9], or_matrix.m[10];
-        eigen_tf.translation() << or_matrix.trans.x, or_matrix.trans.y, or_matrix.trans.z;
-        return eigen_tf;
-    }
-
-    template <typename Derived>
-        inline OpenRAVE::Vector toOR(Derived const &eigen_v)
-    {
-        BOOST_STATIC_ASSERT(Derived::IsVectorAtCompileTime);
-        if (eigen_v.size() == 3) {
-            return OpenRAVE::Vector(eigen_v[0], eigen_v[1], eigen_v[2]);
-        } else if (eigen_v.size() == 4) {
-            return OpenRAVE::Vector(eigen_v[0], eigen_v[1], eigen_v[2], eigen_v[3]);
-        } else {
-            throw std::invalid_argument(boost::str(
-                                            boost::format("Expected a three or four element vector; got a %d elements.")
-                                            % eigen_v.size()));
-        }
-    }
-
-    template <typename Derived>
-        inline OpenRAVE::Transform toOR(Eigen::Transform<Derived, 3, Eigen::Affine> const &tf)
-    {
-        OpenRAVE::TransformMatrix or_matrix;
-        or_matrix.rotfrommat(
-            tf.matrix()(0, 0), tf.matrix()(0, 1), tf.matrix()(0, 2),
-            tf.matrix()(1, 0), tf.matrix()(1, 1), tf.matrix()(1, 2),
-            tf.matrix()(2, 0), tf.matrix()(2, 1), tf.matrix()(2, 2)
-            );
-        or_matrix.trans.x = tf(0, 3);
-        or_matrix.trans.y = tf(1, 3);
-        or_matrix.trans.z = tf(2, 3);
-        return or_matrix;
-    }
-
+inline Eigen::Vector3d toEigen3(OpenRAVE::Vector const &or_v) {
+    Eigen::Vector3d eigen_v;
+    eigen_v << or_v.x, or_v.y, or_v.z;
+    return eigen_v;
 }
 
-#endif
+inline Eigen::Affine3d toEigen(OpenRAVE::Transform const &or_tf) {
+    OpenRAVE::TransformMatrix or_matrix(or_tf);
+    Eigen::Affine3d eigen_tf = Eigen::Affine3d::Identity();
+    eigen_tf.linear() << or_matrix.m[0], or_matrix.m[1], or_matrix.m[2],
+        or_matrix.m[4], or_matrix.m[5], or_matrix.m[6],
+        or_matrix.m[8], or_matrix.m[9], or_matrix.m[10];
+    eigen_tf.translation() << or_matrix.trans.x, or_matrix.trans.y, or_matrix.trans.z;
+    return eigen_tf;
+}
+
+template <typename Derived>
+inline OpenRAVE::Vector toOR(Derived const &eigen_v) {
+    BOOST_STATIC_ASSERT(Derived::IsVectorAtCompileTime);
+    if (eigen_v.size() == 3) {
+        return OpenRAVE::Vector(eigen_v[0], eigen_v[1], eigen_v[2]);
+    } else if (eigen_v.size() == 4) {
+        return OpenRAVE::Vector(eigen_v[0], eigen_v[1], eigen_v[2], eigen_v[3]);
+    } else {
+        throw std::invalid_argument(boost::str(
+                                        boost::format("Expected a three or four element vector; got a %d elements.")
+                                        % eigen_v.size()));
+    }
+}
+
+template <typename Derived>
+inline OpenRAVE::Transform toOR(Eigen::Transform<Derived, 3, Eigen::Affine> const &tf) {
+    OpenRAVE::TransformMatrix or_matrix;
+    or_matrix.rotfrommat(
+        tf.matrix()(0, 0), tf.matrix()(0, 1), tf.matrix()(0, 2),
+        tf.matrix()(1, 0), tf.matrix()(1, 1), tf.matrix()(1, 2),
+        tf.matrix()(2, 0), tf.matrix()(2, 1), tf.matrix()(2, 2)
+        );
+    or_matrix.trans.x = tf(0, 3);
+    or_matrix.trans.y = tf(1, 3);
+    or_matrix.trans.z = tf(2, 3);
+    return or_matrix;
+}
+
+} // namespace or_ompl
+
+#endif // OR_OMPL_OR_CONVERSIONS_H_

--- a/src/OMPLConversions.cpp
+++ b/src/OMPLConversions.cpp
@@ -34,17 +34,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <boost/make_shared.hpp>
 #include <ompl/config.h>
-#include <or_ompl/OMPLConversions.h>
 
-#define OMPL_VERSION_COMP (  OMPL_MAJOR_VERSION * 1000000 \
-                           + OMPL_MINOR_VERSION * 1000 \
-                           + OMPL_PATCH_VERSION)
+#include <or_ompl/OMPLConversions.h>
 
 namespace or_ompl {
 
 void OpenRAVEHandler::log(std::string const &text, ompl::msg::LogLevel level,
-                          char const *filename, int line)
-{
+                          char const *filename, int line) {
+
     int const openrave_level = (OpenRAVE::RaveGetDebugLevel()
                               & OpenRAVE::Level_OutputMask);
 
@@ -87,8 +84,7 @@ void OpenRAVEHandler::log(std::string const &text, ompl::msg::LogLevel level,
     }
 }
 
-std::vector<bool> GetContinuousJoints(const OpenRAVE::RobotBasePtr robot, const std::vector<int> idx)
-{
+std::vector<bool> GetContinuousJoints(const OpenRAVE::RobotBasePtr robot, const std::vector<int> idx) {
     const std::vector<OpenRAVE::RobotBase::JointPtr>& joints = robot->GetJoints();
     std::vector<bool> isContinuous;
     for (size_t j = 0; j < idx.size(); j++)
@@ -99,8 +95,7 @@ std::vector<bool> GetContinuousJoints(const OpenRAVE::RobotBasePtr robot, const 
 }
 
 ompl::base::StateSpacePtr CreateStateSpace(OpenRAVE::RobotBasePtr const robot,
-                                           OMPLPlannerParameters const &params)
-{
+                                           OMPLPlannerParameters const &params) {
     if (!robot) {
         RAVELOG_ERROR("Robot must not be NULL.\n");
         return ompl::base::StateSpacePtr();
@@ -203,8 +198,7 @@ ompl::base::StateSpacePtr CreateStateSpace(OpenRAVE::RobotBasePtr const robot,
 OpenRAVE::PlannerStatus ToORTrajectory(
         OpenRAVE::RobotBasePtr const &robot,
         ompl::geometric::PathGeometric& ompl_traj,
-        OpenRAVE::TrajectoryBasePtr or_traj)
-{
+        OpenRAVE::TrajectoryBasePtr or_traj) {
     using ompl::geometric::PathGeometric;
 
     size_t const num_dof = robot->GetActiveDOF();
@@ -220,4 +214,4 @@ OpenRAVE::PlannerStatus ToORTrajectory(
     return OpenRAVE::PS_HasSolution;
 }
 
-}
+} // namespace or_ompl

--- a/src/OMPLMain.cpp
+++ b/src/OMPLMain.cpp
@@ -27,6 +27,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 *************************************************************************/
+
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/bind.hpp>
 #include <boost/lexical_cast.hpp>
@@ -35,6 +36,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <boost/function.hpp>
 #include <boost/make_shared.hpp>
 #include <openrave/plugin.h>
+
 #include <or_ompl/OMPLPlanner.h>
 #include <or_ompl/OMPLConversions.h>
 #include <or_ompl/OMPLSimplifer.h>
@@ -44,8 +46,7 @@ using namespace OpenRAVE;
 
 InterfaceBasePtr CreateInterfaceValidated(
         InterfaceType type, std::string const &interfacename,
-        std::istream &sinput, EnvironmentBasePtr penv)
-{
+        std::istream &sinput, EnvironmentBasePtr penv) {
     std::vector<std::string> const planner_names
         = or_ompl::registry::get_planner_names();
 
@@ -72,8 +73,7 @@ InterfaceBasePtr CreateInterfaceValidated(
     return InterfaceBasePtr();
 }
 
-void GetPluginAttributesValidated(PLUGININFO &info)
-{
+void GetPluginAttributesValidated(PLUGININFO &info) {
     std::vector<std::string> const planner_names
         = or_ompl::registry::get_planner_names();
 
@@ -89,6 +89,5 @@ void GetPluginAttributesValidated(PLUGININFO &info)
     ompl::msg::useOutputHandler(new or_ompl::OpenRAVEHandler);
 }
 
-RAVE_PLUGIN_API void DestroyPlugin()
-{
+RAVE_PLUGIN_API void DestroyPlugin() {
 }

--- a/src/OMPLPlanner.cpp
+++ b/src/OMPLPlanner.cpp
@@ -31,6 +31,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 *************************************************************************/
+
 #include <time.h>
 #include <tinyxml.h>
 #include <boost/chrono.hpp>
@@ -41,21 +42,20 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ompl/base/StateSpaceTypes.h>
 #include <ompl/base/StateSpace.h>
 #include <ompl/base/spaces/RealVectorStateSpace.h>
+
 #include <or_ompl/OMPLConversions.h>
 #include <or_ompl/OMPLPlanner.h>
 #include <or_ompl/TSRGoal.h>
 #include <or_ompl/PlannerRegistry.h>
 
-namespace or_ompl
-{
+namespace or_ompl {
 
 OMPLPlanner::OMPLPlanner(OpenRAVE::EnvironmentBasePtr penv,
                          PlannerFactory const &planner_factory)
     : OpenRAVE::PlannerBase(penv)
     , m_initialized(false)
-    , m_planner_factory(planner_factory)
+    , m_planner_factory(planner_factory) {
 
-{
     RegisterCommand("GetParameters",
         boost::bind(&OMPLPlanner::GetParametersCommand, this, _1, _2),
         "returns the list of accepted planner parameters"
@@ -72,20 +72,17 @@ OMPLPlanner::OMPLPlanner(OpenRAVE::EnvironmentBasePtr penv,
 
 }
 
-OMPLPlanner::~OMPLPlanner()
-{
+OMPLPlanner::~OMPLPlanner() {
 }
 
-bool OMPLPlanner::InitPlan(OpenRAVE::RobotBasePtr robot, std::istream& input)
-{
+bool OMPLPlanner::InitPlan(OpenRAVE::RobotBasePtr robot, std::istream& input) {
     OMPLPlannerParametersPtr params = boost::make_shared<OMPLPlannerParameters>();
     input >> *params;
     return InitPlan(robot, params);
 }
 
 bool OMPLPlanner::InitPlan(OpenRAVE::RobotBasePtr robot,
-                           PlannerParametersConstPtr params_raw)
-{
+                           PlannerParametersConstPtr params_raw) {
     m_initialized = false;
 
     try {
@@ -246,8 +243,7 @@ bool OMPLPlanner::InitPlan(OpenRAVE::RobotBasePtr robot,
 }
 
 ompl::base::PlannerPtr OMPLPlanner::CreatePlanner(
-    OMPLPlannerParameters const &params)
-{
+    OMPLPlannerParameters const &params) {
     // Create the planner.
     ompl::base::SpaceInformationPtr const spaceInformation
             = m_simple_setup->getSpaceInformation();
@@ -321,8 +317,7 @@ ompl::base::PlannerPtr OMPLPlanner::CreatePlanner(
     return planner;
 }
 
-OpenRAVE::PlannerStatus OMPLPlanner::PlanPath(OpenRAVE::TrajectoryBasePtr ptraj)
-{
+OpenRAVE::PlannerStatus OMPLPlanner::PlanPath(OpenRAVE::TrajectoryBasePtr ptraj) {
     if (!m_initialized) {
         RAVELOG_ERROR("Unable to plan. Did you call InitPlan?\n");
         return OpenRAVE::PS_Failed;
@@ -367,8 +362,7 @@ OpenRAVE::PlannerStatus OMPLPlanner::PlanPath(OpenRAVE::TrajectoryBasePtr ptraj)
     return planner_status;
 }
 
-bool OMPLPlanner::GetParametersCommand(std::ostream &sout, std::istream &sin) const
-{
+bool OMPLPlanner::GetParametersCommand(std::ostream &sout, std::istream &sin) const {
     typedef std::map<std::string, ompl::base::GenericParamPtr> ParamMap;
 
     ompl::base::PlannerPtr planner;
@@ -400,8 +394,7 @@ bool OMPLPlanner::GetParametersCommand(std::ostream &sout, std::istream &sin) co
     return true;
 }
 
-bool OMPLPlanner::GetParameterValCommand(std::ostream &sout, std::istream &sin) const
-{
+bool OMPLPlanner::GetParameterValCommand(std::ostream &sout, std::istream &sin) const {
     typedef std::map<std::string, ompl::base::GenericParamPtr> ParamMap;
     //Obtain argument from input stream
     std::string inp_arg;
@@ -443,16 +436,14 @@ bool OMPLPlanner::GetParameterValCommand(std::ostream &sout, std::istream &sin) 
 
 
     return true;
-
 }
 
 
-bool OMPLPlanner::GetTimes(std::ostream & sout, std::istream & sin) const
-{
+bool OMPLPlanner::GetTimes(std::ostream & sout, std::istream & sin) const {
     sout << "checktime " << m_or_validity_checker->getTotalCollisionTime();
     sout << " totaltime " << m_totalPlanningTime;
     sout << " n_checks " << m_or_validity_checker->getNumCollisionChecks();
     return true;
 }
 
-}
+} // namespace or_ompl

--- a/src/OMPLSimplifier.cpp
+++ b/src/OMPLSimplifier.cpp
@@ -29,9 +29,11 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 *************************************************************************/
+
 #include <boost/make_shared.hpp>
 #include <ompl/base/ScopedState.h>
 #include <ompl/util/Time.h>
+
 #include <or_ompl/OMPLConversions.h>
 #include <or_ompl/OMPLSimplifer.h>
 
@@ -42,21 +44,17 @@ using OpenRAVE::PA_ReturnWithAnySolution;
 using OpenRAVE::PS_HasSolution;
 using OpenRAVE::PS_InterruptedWithSolution;
 
-namespace or_ompl
-{
+namespace or_ompl {
 
 OMPLSimplifier::OMPLSimplifier(OpenRAVE::EnvironmentBasePtr env)
-    : OpenRAVE::PlannerBase(env)
-{
+    : OpenRAVE::PlannerBase(env) {
 }
 
-OMPLSimplifier::~OMPLSimplifier()
-{
+OMPLSimplifier::~OMPLSimplifier() {
 }
 
 bool OMPLSimplifier::InitPlan(OpenRAVE::RobotBasePtr robot,
-                              PlannerParametersConstPtr params_raw)
-{
+                              PlannerParametersConstPtr params_raw) {
     if (!robot) {
         RAVELOG_ERROR("Robot must not be NULL.\n");
         return false;
@@ -97,15 +95,13 @@ bool OMPLSimplifier::InitPlan(OpenRAVE::RobotBasePtr robot,
     }
 }
 
-bool OMPLSimplifier::InitPlan(OpenRAVE::RobotBasePtr robot, std::istream &input)
-{
+bool OMPLSimplifier::InitPlan(OpenRAVE::RobotBasePtr robot, std::istream &input) {
     OMPLPlannerParametersPtr params = boost::make_shared<OMPLPlannerParameters>();
     input >> *params;
     return InitPlan(robot, params);
 }
 
-OpenRAVE::PlannerStatus OMPLSimplifier::PlanPath(OpenRAVE::TrajectoryBasePtr ptraj)
-{
+OpenRAVE::PlannerStatus OMPLSimplifier::PlanPath(OpenRAVE::TrajectoryBasePtr ptraj) {
     typedef ompl::base::ScopedState<ompl::base::StateSpace> ScopedState;
 
     if (!m_simplifier) {
@@ -212,4 +208,4 @@ OpenRAVE::PlannerStatus OMPLSimplifier::PlanPath(OpenRAVE::TrajectoryBasePtr ptr
     }
 }
 
-}
+} // namespace or_ompl

--- a/src/StateSpaces.cpp
+++ b/src/StateSpaces.cpp
@@ -1,7 +1,42 @@
+/***********************************************************************
+
+Copyright (c) 2014, Carnegie Mellon University
+All rights reserved.
+
+Authors: Michael Koval <mkoval@cs.cmu.edu>
+         Matthew Klingensmith <mklingen@cs.cmu.edu>
+         Christopher Dellin <cdellin@cs.cmu.edu>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+  Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*************************************************************************/
+
 #include <boost/chrono.hpp>
 #include <boost/foreach.hpp>
-#include <ompl/base/SpaceInformation.h>
 #include <openrave/openrave.h>
+#include <ompl/base/SpaceInformation.h>
+
 #include <or_ompl/StateSpaces.h>
 
 using namespace or_ompl;
@@ -126,13 +161,11 @@ or_ompl::OrStateValidityChecker::OrStateValidityChecker(
         OpenRAVE::RobotBasePtr robot, std::vector<int> const &indices):
     ompl::base::StateValidityChecker(si),
     m_stateSpace(si->getStateSpace().get()),
-    m_env(robot->GetEnv()), m_robot(robot), m_indices(indices)
-{
+    m_env(robot->GetEnv()), m_robot(robot), m_indices(indices) {
     resetStatistics();
 }
 
-bool or_ompl::OrStateValidityChecker::computeFk(const ompl::base::State *state, uint32_t checklimits) const
-{
+bool or_ompl::OrStateValidityChecker::computeFk(const ompl::base::State *state, uint32_t checklimits) const {
     std::vector<double> values;
     m_stateSpace->copyToReals(values, state);
     
@@ -147,8 +180,7 @@ bool or_ompl::OrStateValidityChecker::computeFk(const ompl::base::State *state, 
     return true;
 }
 
-bool or_ompl::OrStateValidityChecker::isValid(const ompl::base::State *state) const
-{
+bool or_ompl::OrStateValidityChecker::isValid(const ompl::base::State *state) const {
     boost::chrono::steady_clock::time_point const tic
        = boost::chrono::steady_clock::now();
     
@@ -169,12 +201,10 @@ or_ompl::RealVectorOrStateValidityChecker::RealVectorOrStateValidityChecker(
         const ompl::base::SpaceInformationPtr &si,
         OpenRAVE::RobotBasePtr robot, std::vector<int> const &indices):
     or_ompl::OrStateValidityChecker(si,robot,indices),
-    m_num_dof(si->getStateDimension())
-{
+    m_num_dof(si->getStateDimension()) {
 }
 
-bool or_ompl::RealVectorOrStateValidityChecker::computeFk(const ompl::base::State *state, uint32_t checklimits) const
-{
+bool or_ompl::RealVectorOrStateValidityChecker::computeFk(const ompl::base::State *state, uint32_t checklimits) const {
     ompl::base::RealVectorStateSpace::StateType const * real_state
         = state->as<ompl::base::RealVectorStateSpace::StateType>();
     
@@ -190,5 +220,3 @@ bool or_ompl::RealVectorOrStateValidityChecker::computeFk(const ompl::base::Stat
     m_robot->SetDOFValues(values, checklimits, m_indices);
     return true;
 }
-
-

--- a/src/TSR.cpp
+++ b/src/TSR.cpp
@@ -1,154 +1,186 @@
-#include <or_ompl/TSR.h>
+/***********************************************************************
+
+Copyright (c) 2014, Carnegie Mellon University
+All rights reserved.
+
+Authors: Jennifer King <jeking04@gmail.com>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+  Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*************************************************************************/
+
+#include <vector>
 #include <Eigen/Geometry>
 #include <ompl/util/RandomNumbers.h>
-#include <vector>
+
+#include <or_ompl/TSR.h>
 
 using namespace or_ompl;
 
 TSR::TSR() : _initialized(false) {
-
 }
 
 TSR::TSR(const Eigen::Affine3d &T0_w, const Eigen::Affine3d &Tw_e, const Eigen::Matrix<double, 6, 2> &Bw) :
-	_T0_w(T0_w), _Tw_e(Tw_e), _Bw(Bw), _initialized(true) {
+    _T0_w(T0_w), _Tw_e(Tw_e), _Bw(Bw), _initialized(true) {
 
-	_T0_w_inv = _T0_w.inverse();
-	_Tw_e_inv = _Tw_e.inverse();
+    _T0_w_inv = _T0_w.inverse();
+    _Tw_e_inv = _Tw_e.inverse();
 
 }
 
 bool TSR::deserialize(std::stringstream &ss) {
 
-	// TODO: Do we need this stuff? 
-	int manipind_ignored;
+    // TODO: Do we need this stuff? 
+    int manipind_ignored;
     ss >> manipind_ignored;
 
-	std::string relativebodyname_ignored;
+    std::string relativebodyname_ignored;
     ss >> relativebodyname_ignored;
    
     if( relativebodyname_ignored != "NULL" )
     {
-		std::string relativelinkname_ignored;
+        std::string relativelinkname_ignored;
         ss >> relativelinkname_ignored;  
     }  
     
-	// Read in the T0_w matrix 
-	double tmp;
-	for(unsigned int c=0; c < 3; c++){
-		for(unsigned int r=0; r < 3; r++){
-			ss >> tmp;
-			_T0_w.matrix()(r,c) = tmp;
-		}
-	}
+    // Read in the T0_w matrix 
+    double tmp;
+    for(unsigned int c=0; c < 3; c++){
+        for(unsigned int r=0; r < 3; r++){
+            ss >> tmp;
+            _T0_w.matrix()(r,c) = tmp;
+        }
+    }
 
-	for(unsigned int idx=0; idx < 3; idx++){
-		ss >> tmp;
-		_T0_w.translation()(idx) = tmp;
-	}	
+    for(unsigned int idx=0; idx < 3; idx++){
+        ss >> tmp;
+        _T0_w.translation()(idx) = tmp;
+    }    
 
-	// Read in the Tw_e matrix 
-	for(unsigned int c=0; c < 3; c++){
-		for(unsigned int r=0; r < 3; r++){
-			ss >> tmp;
-			_Tw_e.matrix()(r,c) = tmp;
-		}
-	}
+    // Read in the Tw_e matrix 
+    for(unsigned int c=0; c < 3; c++){
+        for(unsigned int r=0; r < 3; r++){
+            ss >> tmp;
+            _Tw_e.matrix()(r,c) = tmp;
+        }
+    }
 
-	for(unsigned int idx=0; idx < 3; idx++){
-		ss >> tmp;
-		_Tw_e.translation()(idx) = tmp;
-	}
+    for(unsigned int idx=0; idx < 3; idx++){
+        ss >> tmp;
+        _Tw_e.translation()(idx) = tmp;
+    }
 
-	// Read in the Bw matrix 
-	for(unsigned int r=0; r < 6; r++){
-		for(unsigned int c=0; c < 2; c++){
-			ss >> tmp;
-			_Bw(r,c) = tmp;
-		}
-	}
+    // Read in the Bw matrix 
+    for(unsigned int r=0; r < 6; r++){
+        for(unsigned int c=0; c < 2; c++){
+            ss >> tmp;
+            _Bw(r,c) = tmp;
+        }
+    }
 
-	_T0_w_inv = _T0_w.inverse();
-	_Tw_e_inv = _Tw_e.inverse();
+    _T0_w_inv = _T0_w.inverse();
+    _Tw_e_inv = _Tw_e.inverse();
 
-	_initialized = true;
+    _initialized = true;
 
     return _initialized;
 }
 
 
 Eigen::Matrix<double, 6, 1> TSR::distance(const Eigen::Affine3d &ee_pose) const {
-	Eigen::Matrix<double, 6, 1> dist = Eigen::Matrix<double, 6, 1>::Zero();
+    Eigen::Matrix<double, 6, 1> dist = Eigen::Matrix<double, 6, 1>::Zero();
 
-	// First compute the pose of the w frame in world coordinates, given the ee_pose
-	Eigen::Affine3d w_in_world = ee_pose * _Tw_e_inv;
-	
-	// Next compute the pose of the w frame relative to its original pose (as specified by T0_w)
-	Eigen::Affine3d w_offset = _T0_w_inv * w_in_world;
+    // First compute the pose of the w frame in world coordinates, given the ee_pose
+    Eigen::Affine3d w_in_world = ee_pose * _Tw_e_inv;
+    
+    // Next compute the pose of the w frame relative to its original pose (as specified by T0_w)
+    Eigen::Affine3d w_offset = _T0_w_inv * w_in_world;
 
-	// Now compute the elements of the distance matrix
-	dist(0,0) = w_offset.translation()(0);
-	dist(1,0) = w_offset.translation()(1);
-	dist(2,0) = w_offset.translation()(2);
-	dist(3,0) = atan2(w_offset.rotation()(2,1), w_offset.rotation()(2,2));
-	dist(4,0) = -asin(w_offset.rotation()(2,0));
-	dist(5,0) = atan2(w_offset.rotation()(1,0), w_offset.rotation()(0,0));
+    // Now compute the elements of the distance matrix
+    dist(0,0) = w_offset.translation()(0);
+    dist(1,0) = w_offset.translation()(1);
+    dist(2,0) = w_offset.translation()(2);
+    dist(3,0) = atan2(w_offset.rotation()(2,1), w_offset.rotation()(2,2));
+    dist(4,0) = -asin(w_offset.rotation()(2,0));
+    dist(5,0) = atan2(w_offset.rotation()(1,0), w_offset.rotation()(0,0));
 
-	return dist;
+    return dist;
 }
 
 Eigen::Matrix<double, 6, 1> TSR::displacement(const Eigen::Affine3d &ee_pose) const {
 
-	Eigen::Matrix<double, 6, 1> dist = distance(ee_pose);
-	Eigen::Matrix<double, 6, 1> disp = Eigen::Matrix<double, 6, 1>::Zero();
+    Eigen::Matrix<double, 6, 1> dist = distance(ee_pose);
+    Eigen::Matrix<double, 6, 1> disp = Eigen::Matrix<double, 6, 1>::Zero();
 
-	for(unsigned int idx=0; idx < 6; idx++){
-		
-		if(dist(idx,0) < _Bw(idx,0)){
-			disp(idx,0) = dist(idx,0) - _Bw(idx,0);
-		}else if(dist(idx,0) > _Bw(idx,1)){
-			disp(idx,0) = dist(idx,0) - _Bw(idx,1);
-		}
-	}
+    for(unsigned int idx=0; idx < 6; idx++){
+        
+        if(dist(idx,0) < _Bw(idx,0)){
+            disp(idx,0) = dist(idx,0) - _Bw(idx,0);
+        }else if(dist(idx,0) > _Bw(idx,1)){
+            disp(idx,0) = dist(idx,0) - _Bw(idx,1);
+        }
+    }
 
-	return disp;
+    return disp;
 }
 
 Eigen::Affine3d TSR::sampleDisplacementTransform(void) const {
 
-	// First sample uniformly betwee each of the bounds of Bw
-	std::vector<double> d_sample(6);
-	
-	ompl::RNG rng;
-	for(unsigned int idx=0; idx < d_sample.size(); idx++){
-		if(_Bw(idx,1) > _Bw(idx,0)){
-			d_sample[idx] = rng.uniformReal(_Bw(idx,0), _Bw(idx,1)); 		
-		}
-	}
+    // First sample uniformly betwee each of the bounds of Bw
+    std::vector<double> d_sample(6);
+    
+    ompl::RNG rng;
+    for(unsigned int idx=0; idx < d_sample.size(); idx++){
+        if(_Bw(idx,1) > _Bw(idx,0)){
+            d_sample[idx] = rng.uniformReal(_Bw(idx,0), _Bw(idx,1));         
+        }
+    }
 
-	Eigen::Affine3d return_tf;
-	return_tf.translation() << d_sample[0], d_sample[1], d_sample[2];
+    Eigen::Affine3d return_tf;
+    return_tf.translation() << d_sample[0], d_sample[1], d_sample[2];
 
-	// Convert to a transform matrix
-	double roll = d_sample[3];
-	double pitch = d_sample[4];
-	double yaw = d_sample[5];
+    // Convert to a transform matrix
+    double roll = d_sample[3];
+    double pitch = d_sample[4];
+    double yaw = d_sample[5];
 
-	double A = cos(yaw);
-	double B = sin(yaw);
-	double C = cos(pitch);
-	double D = sin(pitch);
-	double E = cos(roll);
-	double F = sin(roll);
-	return_tf.linear() << A*C, A*D*F - B*E, B*F + A*D*E,
-		B*C, A*E + B*D*F, B*D*E - A*F,
-		-D, C*F, C*E;
+    double A = cos(yaw);
+    double B = sin(yaw);
+    double C = cos(pitch);
+    double D = sin(pitch);
+    double E = cos(roll);
+    double F = sin(roll);
+    return_tf.linear() << A*C, A*D*F - B*E, B*F + A*D*E,
+        B*C, A*E + B*D*F, B*D*E - A*F,
+        -D, C*F, C*E;
 
-	return return_tf;
+    return return_tf;
 }
 
 Eigen::Affine3d TSR::sample() const {
 
-	Eigen::Affine3d tf = sampleDisplacementTransform(); 
-	
-	return _T0_w * tf * _Tw_e;
+    Eigen::Affine3d tf = sampleDisplacementTransform(); 
+    
+    return _T0_w * tf * _Tw_e;
 }

--- a/src/TSRChain.cpp
+++ b/src/TSRChain.cpp
@@ -1,9 +1,41 @@
-#include <or_ompl/TSRChain.h>
+/***********************************************************************
+
+Copyright (c) 2014, Carnegie Mellon University
+All rights reserved.
+
+Authors: Jennifer King <jeking04@gmail.com>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+  Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*************************************************************************/
 
 #include <limits>
 #include <vector>
 #include <boost/foreach.hpp>
 #include <boost/make_shared.hpp>
+
+#include <or_ompl/TSRChain.h>
 
 using namespace or_ompl;
 
@@ -12,60 +44,60 @@ TSRChain::TSRChain() : _initialized(false), _sample_start(false), _sample_goal(f
 }
 
 TSRChain::TSRChain(const bool &sample_start, 
-				   const bool &sample_goal, 
-				   const bool &constrain,
-				   const std::vector<TSR::Ptr> &tsrs) :
-	_initialized(true), _sample_start(sample_start), _sample_goal(sample_goal),
-	_constrain(constrain), _tsrs(tsrs), _tsr_robot(TSRRobot::Ptr()) {
+                   const bool &sample_goal, 
+                   const bool &constrain,
+                   const std::vector<TSR::Ptr> &tsrs) :
+    _initialized(true), _sample_start(sample_start), _sample_goal(sample_goal),
+    _constrain(constrain), _tsrs(tsrs), _tsr_robot(TSRRobot::Ptr()) {
 
 }
 
 bool TSRChain::deserialize(std::stringstream &ss) {
 
-	ss >> _sample_start;
-	ss >> _sample_goal;
-	ss >> _constrain;
+    ss >> _sample_start;
+    ss >> _sample_goal;
+    ss >> _constrain;
 
-	int num_tsrs;
-	ss >> num_tsrs;
+    int num_tsrs;
+    ss >> num_tsrs;
 
-	_tsrs.resize(num_tsrs);
+    _tsrs.resize(num_tsrs);
     bool valid = true;
-	for(unsigned int idx = 0; idx < num_tsrs; idx++){
-		TSR::Ptr new_tsr = boost::make_shared<TSR>();
-		valid &= new_tsr->deserialize(ss);
-		_tsrs[idx] = new_tsr;
-	}
+    for(unsigned int idx = 0; idx < num_tsrs; idx++){
+        TSR::Ptr new_tsr = boost::make_shared<TSR>();
+        valid &= new_tsr->deserialize(ss);
+        _tsrs[idx] = new_tsr;
+    }
 
     return valid;
 
-	// TODO: Ignored are mmicbody name and mimicbodyjoints	
+    // TODO: Ignored are mmicbody name and mimicbodyjoints    
 }
 
 Eigen::Affine3d TSRChain::sample() const {
 
-	Eigen::Affine3d T0_w;
-	if(_tsrs.size() == 0){
+    Eigen::Affine3d T0_w;
+    if(_tsrs.size() == 0){
         throw OpenRAVE::openrave_exception(
             "There are no TSRs in this TSR Chain.",
             OpenRAVE::ORE_InvalidState
         );
-	}
+    }
 
-	T0_w = _tsrs.front()->getOriginTransform();
-	BOOST_FOREACH(TSR::Ptr tsr, _tsrs){
-		T0_w  = T0_w * tsr->sampleDisplacementTransform() * tsr->getEndEffectorOffsetTransform();
-	}
+    T0_w = _tsrs.front()->getOriginTransform();
+    BOOST_FOREACH(TSR::Ptr tsr, _tsrs){
+        T0_w  = T0_w * tsr->sampleDisplacementTransform() * tsr->getEndEffectorOffsetTransform();
+    }
 
-	return T0_w;
+    return T0_w;
 }
 
 Eigen::Matrix<double, 6, 1> TSRChain::distance(const Eigen::Affine3d &ee_pose) const {
 
-	if(_tsrs.size() == 1){
-		TSR::Ptr tsr = _tsrs.front();
-		return tsr->distance(ee_pose);
-	}
+    if(_tsrs.size() == 1){
+        TSR::Ptr tsr = _tsrs.front();
+        return tsr->distance(ee_pose);
+    }
      
     if(!_tsr_robot){
         throw OpenRAVE::openrave_exception(
@@ -93,16 +125,16 @@ Eigen::Matrix<double, 6, 1> TSRChain::distance(const Eigen::Affine3d &ee_pose) c
     Eigen::Affine3d offset = Tnear.inverse() * Ttarget;
     Eigen::Matrix<double, 6, 1> dist = Eigen::Matrix<double, 6, 1>::Zero();
     dist[0] = offset.translation()[0];
-	dist[1] = offset.translation()[1];
-	dist[2] = offset.translation()[2];
-	dist[3] = atan2(offset.rotation()(2,1), offset.rotation()(2,2));
-	dist[4] = -asin(offset.rotation()(2,0));
-	dist[5] = atan2(offset.rotation()(1,0), offset.rotation()(0,0));
+    dist[1] = offset.translation()[1];
+    dist[2] = offset.translation()[2];
+    dist[3] = atan2(offset.rotation()(2,1), offset.rotation()(2,2));
+    dist[4] = -asin(offset.rotation()(2,0));
+    dist[5] = atan2(offset.rotation()(1,0), offset.rotation()(0,0));
 
     return dist;
 }
 
-void TSRChain::setEnv(const OpenRAVE::EnvironmentBasePtr &penv){
+void TSRChain::setEnv(const OpenRAVE::EnvironmentBasePtr &penv) {
 
     _tsr_robot = boost::make_shared<TSRRobot>(_tsrs, penv);
     

--- a/src/TSRGoal.cpp
+++ b/src/TSRGoal.cpp
@@ -1,49 +1,77 @@
-#include <or_ompl/StateSpaces.h>
-#include <or_ompl/TSRGoal.h>
+/***********************************************************************
+
+Copyright (c) 2014, Carnegie Mellon University
+All rights reserved.
+
+Authors: Jennifer King <jeking04@gmail.com>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+  Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*************************************************************************/
 
 #include <boost/foreach.hpp>
 #include <ompl/base/spaces/RealVectorStateSpace.h>
 #include <ompl/util/RandomNumbers.h>
 
+#include <or_ompl/StateSpaces.h>
+#include <or_ompl/TSRGoal.h>
+
 using namespace or_ompl;
 namespace ob = ompl::base;
 
 TSRGoal::TSRGoal(const ob::SpaceInformationPtr &si,
-				 const TSR::Ptr &tsr, 
-				 OpenRAVE::RobotBasePtr robot,
-				 OrStateValidityCheckerPtr or_validity_checker)
+                 const TSR::Ptr &tsr, 
+                 OpenRAVE::RobotBasePtr robot,
+                 OrStateValidityCheckerPtr or_validity_checker)
     : ob::GoalSampleableRegion(si), _robot(robot)
-	, _state_space(si->getStateSpace().get())
-	, _or_validity_checker(or_validity_checker)
-{
+    , _state_space(si->getStateSpace().get())
+    , _or_validity_checker(or_validity_checker) {
     
-	std::vector<TSR::Ptr> tsrs(1);
-	tsrs.push_back(tsr);
-	TSRChain::Ptr tsrchain = boost::make_shared<TSRChain>(true, false, false, tsrs);
-	_tsr_chains.push_back(tsrchain);
+    std::vector<TSR::Ptr> tsrs(1);
+    tsrs.push_back(tsr);
+    TSRChain::Ptr tsrchain = boost::make_shared<TSRChain>(true, false, false, tsrs);
+    _tsr_chains.push_back(tsrchain);
 }
 
 TSRGoal::TSRGoal(const ob::SpaceInformationPtr &si,
-				 const TSRChain::Ptr &tsrchain, 
-				 OpenRAVE::RobotBasePtr robot,
-				 OrStateValidityCheckerPtr or_validity_checker)
+                 const TSRChain::Ptr &tsrchain, 
+                 OpenRAVE::RobotBasePtr robot,
+                 OrStateValidityCheckerPtr or_validity_checker)
     : ob::GoalSampleableRegion(si), _robot(robot)
-	, _state_space(si->getStateSpace().get())
-	, _or_validity_checker(or_validity_checker)
-{
+    , _state_space(si->getStateSpace().get())
+    , _or_validity_checker(or_validity_checker) {
 
-	_tsr_chains.push_back(tsrchain);
+    _tsr_chains.push_back(tsrchain);
 }
 
 TSRGoal::TSRGoal(const ob::SpaceInformationPtr &si,
-				 const std::vector<TSRChain::Ptr> &tsrchains, 
-				 OpenRAVE::RobotBasePtr robot,
-				 OrStateValidityCheckerPtr or_validity_checker)
+                 const std::vector<TSRChain::Ptr> &tsrchains, 
+                 OpenRAVE::RobotBasePtr robot,
+                 OrStateValidityCheckerPtr or_validity_checker)
     : ob::GoalSampleableRegion(si), _tsr_chains(tsrchains), _robot(robot)
-	, _state_space(si->getStateSpace().get())
-	, _or_validity_checker(or_validity_checker)
-{
-    
+    , _state_space(si->getStateSpace().get())
+    , _or_validity_checker(or_validity_checker) {
 }
 
 TSRGoal::~TSRGoal() {
@@ -53,103 +81,103 @@ TSRGoal::~TSRGoal() {
 bool TSRGoal::isSatisfied(const ompl::base::State *state) const {
 
     bool satisfied = (distanceGoal(state) == 0.0);
-	return satisfied;
+    return satisfied;
 }
             
 double TSRGoal::distanceGoal(const ompl::base::State *state) const {
 
-	// Save the state of the robot
+    // Save the state of the robot
     OpenRAVE::EnvironmentMutex::scoped_lock lockenv(_robot->GetEnv()->GetMutex());
-	OpenRAVE::KinBody::KinBodyStateSaver rsaver(_robot);
+    OpenRAVE::KinBody::KinBodyStateSaver rsaver(_robot);
 
     OpenRAVE::RobotBase::ManipulatorPtr active_manip = _robot->GetActiveManipulator();
 
-	// Put the robot in the pose that is represented in the state
+    // Put the robot in the pose that is represented in the state
     unsigned int check_limits = 0; // The planner does this
     _or_validity_checker->computeFk(state, check_limits);
 
-	// Get the end effector transform
-	OpenRAVE::Transform or_tf = active_manip->GetEndEffectorTransform();
+    // Get the end effector transform
+    OpenRAVE::Transform or_tf = active_manip->GetEndEffectorTransform();
     OpenRAVE::TransformMatrix or_matrix(or_tf);
-	
-	// Convert to Eigen
+    
+    // Convert to Eigen
     Eigen::Affine3d ee_pose = Eigen::Affine3d::Identity();
     ee_pose.linear() << or_matrix.m[0], or_matrix.m[1], or_matrix.m[2],
         or_matrix.m[4], or_matrix.m[5], or_matrix.m[6],
         or_matrix.m[8], or_matrix.m[9], or_matrix.m[10];
     ee_pose.translation() << or_matrix.trans.x, or_matrix.trans.y, or_matrix.trans.z;
 
-	// Get distance to TSR
-	double distance = std::numeric_limits<double>::infinity();
-	BOOST_FOREACH(TSRChain::Ptr tsrchain, _tsr_chains){
-		Eigen::Matrix<double, 6, 1> ee_distance = tsrchain->distance(ee_pose);
-		double tdistance = ee_distance.norm();
-		if(tdistance < distance){
-			distance = tdistance;
-		}
-	}
+    // Get distance to TSR
+    double distance = std::numeric_limits<double>::infinity();
+    BOOST_FOREACH(TSRChain::Ptr tsrchain, _tsr_chains){
+        Eigen::Matrix<double, 6, 1> ee_distance = tsrchain->distance(ee_pose);
+        double tdistance = ee_distance.norm();
+        if(tdistance < distance){
+            distance = tdistance;
+        }
+    }
 
-	// Reset the state of the robot
-	rsaver.Restore();
+    // Reset the state of the robot
+    rsaver.Restore();
 
-	return distance;
+    return distance;
 }
             
 void TSRGoal::sampleGoal(ompl::base::State *state) const {
 
-	bool success = false;
+    bool success = false;
 
-	// TODO: Figure out how to bail correctly if an IK isn't found
-	for(unsigned int count=0; count < 20 && !success; count++){
-		// Pick a TSR to sample
-		int idx = 0;
-		if(_tsr_chains.size() > 1){
-			ompl::RNG rng;
-			idx = rng.uniformInt(0, _tsr_chains.size()-1);
-		}
+    // TODO: Figure out how to bail correctly if an IK isn't found
+    for(unsigned int count=0; count < 20 && !success; count++){
+        // Pick a TSR to sample
+        int idx = 0;
+        if(_tsr_chains.size() > 1){
+            ompl::RNG rng;
+            idx = rng.uniformInt(0, _tsr_chains.size()-1);
+        }
 
-		// Sample the TSR
-		Eigen::Affine3d ee_pose = _tsr_chains[idx]->sample();
+        // Sample the TSR
+        Eigen::Affine3d ee_pose = _tsr_chains[idx]->sample();
 
-		// Find an associated IK
-		OpenRAVE::TransformMatrix or_matrix;
-		or_matrix.rotfrommat(
-			ee_pose.matrix()(0, 0), ee_pose.matrix()(0, 1), ee_pose.matrix()(0, 2),
-			ee_pose.matrix()(1, 0), ee_pose.matrix()(1, 1), ee_pose.matrix()(1, 2),
-			ee_pose.matrix()(2, 0), ee_pose.matrix()(2, 1), ee_pose.matrix()(2, 2)
-			);
-		or_matrix.trans.x = ee_pose(0, 3);
-		or_matrix.trans.y = ee_pose(1, 3);
-		or_matrix.trans.z = ee_pose(2, 3);
+        // Find an associated IK
+        OpenRAVE::TransformMatrix or_matrix;
+        or_matrix.rotfrommat(
+            ee_pose.matrix()(0, 0), ee_pose.matrix()(0, 1), ee_pose.matrix()(0, 2),
+            ee_pose.matrix()(1, 0), ee_pose.matrix()(1, 1), ee_pose.matrix()(1, 2),
+            ee_pose.matrix()(2, 0), ee_pose.matrix()(2, 1), ee_pose.matrix()(2, 2)
+            );
+        or_matrix.trans.x = ee_pose(0, 3);
+        or_matrix.trans.y = ee_pose(1, 3);
+        or_matrix.trans.z = ee_pose(2, 3);
 
-		OpenRAVE::IkParameterization ik_param(or_matrix, OpenRAVE::IKP_Transform6D);
-		std::vector<OpenRAVE::dReal> ik_solution;
-		success = _robot->GetActiveManipulator()->FindIKSolution(ik_param, ik_solution, OpenRAVE::IKFO_CheckEnvCollisions);
+        OpenRAVE::IkParameterization ik_param(or_matrix, OpenRAVE::IKP_Transform6D);
+        std::vector<OpenRAVE::dReal> ik_solution;
+        success = _robot->GetActiveManipulator()->FindIKSolution(ik_param, ik_solution, OpenRAVE::IKFO_CheckEnvCollisions);
 
-		// Set the state
-		if(success){
+        // Set the state
+        if(success){
 
             std::vector<int> arm_indices = _robot->GetActiveManipulator()->GetArmIndices();
             const std::vector<int> & state_indices = _or_validity_checker->getIndices();
             std::vector<double> values(state_indices.size());
-			for(unsigned int idx=0; idx < ik_solution.size(); idx++){
+            for(unsigned int idx=0; idx < ik_solution.size(); idx++){
 
                 unsigned int sidx = std::find(state_indices.begin(),
                                               state_indices.end(),
                                               arm_indices[idx]) - state_indices.begin();
 
-				values[sidx] = ik_solution[idx];
-			}
-			_state_space->copyFromReals(state, values);
-		}
-	}
+                values[sidx] = ik_solution[idx];
+            }
+            _state_space->copyFromReals(state, values);
+        }
+    }
 
-	if(!success){
-		RAVELOG_ERROR("[TSRGoal] Failed to sample valid goal.\n");
+    if(!success){
+        RAVELOG_ERROR("[TSRGoal] Failed to sample valid goal.\n");
         const std::vector<int> & state_indices = _or_validity_checker->getIndices();
         std::vector<double> values(state_indices.size(), std::numeric_limits<double>::quiet_NaN());
         _state_space->copyFromReals(state, values);
-	}
+    }
 }
 
 unsigned int TSRGoal::maxSampleCount() const {

--- a/src/TSRRobot.cpp
+++ b/src/TSRRobot.cpp
@@ -1,13 +1,45 @@
+/***********************************************************************
+
+Copyright (c) 2014, Carnegie Mellon University
+All rights reserved.
+
+Authors: Jennifer King <jeking04@gmail.com>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+  Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*************************************************************************/
+
+#include <boost/make_shared.hpp>
+
 #include <or_ompl/TSRRobot.h>
 #include <or_ompl/or_conversions.h>
-#include <boost/make_shared.hpp>
 
 using namespace or_ompl;
 
 TSRRobot::TSRRobot(const std::vector<TSR::Ptr> &tsrs, const OpenRAVE::EnvironmentBasePtr &penv)
     : _tsrs(tsrs), _penv(penv), _initialized(false), _solver("GeneralIK") {
 
- 
 }
 
 bool TSRRobot::construct() {


### PR DESCRIPTION
This PR cleans up a bunch of formatting and standardizes legal headers, include guards, namespaces, tabs -> spaces, etc.  No actual changes (besides removing an unused `OMPL_VERSION_COMP` macro).