### PR TITLE
Updated logging for new OpenRAVE release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,22 @@ find_package(OpenRAVE REQUIRED)
 find_package(TinyXML REQUIRED)
 find_package(Eigen REQUIRED)
 
-# 2013-01-05: int options arg added to PlannerParameters::serialize
+# Setup compilation options for the check_cxx_source_compiles tests below.
 set(CMAKE_REQUIRED_INCLUDES ${OpenRAVE_INCLUDE_DIRS})
-set(CMAKE_REQUIRED_LIBRARIES ${OpenRAVE_LIBRARIES} ${Boost_LIBRARIES})
+set(CMAKE_REQUIRED_LIBRARIES
+  ${Boost_LIBRARIES}
+  ${OpenRAVE_CORE_LIBRARIES}
+  ${OpenRAVE_LIBRARIES})
+set(CMAKE_REQUIRED_DEFINITIONS
+  ${OpenRAVE_CXX_FLAGS}
+  ${OpenRAVE_LINK_FLAGS})
+
+set(CMAKE_REQUIRED_FLAGS)
+foreach(dir ${OpenRAVE_LIBRARY_DIRS})
+  list(APPEND CMAKE_REQUIRED_FLAGS "-L${dir}")
+endforeach()
+
+# 2013-01-05: int options arg added to PlannerParameters::serialize
 check_cxx_source_compiles(
     "#include <openrave/openrave.h>
     class P: OpenRAVE::PlannerBase::PlannerParameters
@@ -20,11 +33,6 @@ check_cxx_source_compiles(
     int main(){}"
     OR_OMPL_HAS_PPSEROPTS
 )
-check_cxx_source_compiles(
-    "#include <openrave/openrave.h>
-    int main(){OpenRAVE::RaveGetLogger();}"
-    OR_OMPL_HAS_LOG4CXX
-  )
 
 configure_file(
     "include/${PROJECT_NAME}/config.h.in"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,10 @@ check_cxx_source_compiles(
 
 # 1.2.0 ompl (ROS kinetic) switched from boost to std smart pointers
 set(CMAKE_REQUIRED_INCLUDES ${OMPL_INCLUDE_DIRS})
-set(CMAKE_REQUIRED_LIBRARIES "")
+set(CMAKE_REQUIRED_LIBRARIES)
+set(CMAKE_REQUIRED_DEFINITIONS)
+set(CMAKE_REQUIRED_FLAGS)
+
 check_cxx_source_compiles(
     "#include <ompl/base/StateSpace.h>
     int main(){ ompl::base::StateSpacePtr s = boost::shared_ptr<ompl::base::StateSpace>(); }"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,11 +18,19 @@ check_cxx_source_compiles(
     class P: OpenRAVE::PlannerBase::PlannerParameters
     {void f(){bool (P::*x)(std::ostream&,int) const = &P::serialize;}};
     int main(){}"
-    OR_OMPL_HAS_PPSEROPTS)
-configure_file(
-    include/${PROJECT_NAME}/config.h.in
-    ${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}/config.h
+    OR_OMPL_HAS_PPSEROPTS
 )
+check_cxx_source_compiles(
+    "#include <openrave/openrave.h>
+    int main(){OpenRAVE::RaveGetLogger();}"
+    OR_OMPL_HAS_LOG4CXX
+  )
+
+configure_file(
+    "include/${PROJECT_NAME}/config.h.in"
+    "${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}/config.h"
+)
+
 
 catkin_package(
     INCLUDE_DIRS include ${CATKIN_DEVEL_PREFIX}/include

--- a/include/or_ompl/config.h.in
+++ b/include/or_ompl/config.h.in
@@ -1,1 +1,2 @@
 #cmakedefine OR_OMPL_HAS_PPSEROPTS 1
+#cmakedefine OR_OMPL_HAS_LOG4CXX 1

--- a/include/or_ompl/config.h.in
+++ b/include/or_ompl/config.h.in
@@ -1,2 +1,1 @@
 #cmakedefine OR_OMPL_HAS_PPSEROPTS 1
-#cmakedefine OR_OMPL_HAS_LOG4CXX 1

--- a/src/OMPLConversions.cpp
+++ b/src/OMPLConversions.cpp
@@ -42,45 +42,38 @@ namespace or_ompl {
 void OpenRAVEHandler::log(std::string const &text, ompl::msg::LogLevel level,
                           char const *filename, int line) {
 
-    int const openrave_level = (OpenRAVE::RaveGetDebugLevel()
-                              & OpenRAVE::Level_OutputMask);
+    int const openrave_threshold_level = (
+        OpenRAVE::RaveGetDebugLevel() & OpenRAVE::Level_OutputMask);
+    int openrave_message_level = OpenRAVE::Level_Debug;
 
     switch (level) {
     case ompl::msg::LOG_DEBUG:
-        if (openrave_level >= (int) OpenRAVE::Level_Debug) {
-            OpenRAVE::RavePrintfA_DEBUGLEVEL("[%s:%d] %s\n",
-                OpenRAVE::RaveGetSourceFilename(filename), line,
-                text.c_str());
-        }
+        openrave_message_level = OpenRAVE::Level_Debug;
         break;
 
     case ompl::msg::LOG_INFO:
-        if (openrave_level >= (int) OpenRAVE::Level_Info) {
-            OpenRAVE::RavePrintfA_INFOLEVEL("[%s:%d] %s\n",
-                OpenRAVE::RaveGetSourceFilename(filename), line,
-                text.c_str());
-        }
+        openrave_message_level = OpenRAVE::Level_Info;
         break;
 
     case ompl::msg::LOG_WARN:
-        if (openrave_level >= (int) OpenRAVE::Level_Warn) {
-            OpenRAVE::RavePrintfA_WARNLEVEL("[%s:%d] %s\n",
-                OpenRAVE::RaveGetSourceFilename(filename), line,
-                text.c_str());
-        }
+        openrave_message_level = OpenRAVE::Level_Warn;
         break;
 
     case ompl::msg::LOG_ERROR:
-        if (openrave_level >= (int) OpenRAVE::Level_Error) {
-            OpenRAVE::RavePrintfA_ERRORLEVEL("[%s:%d] %s\n",
-                OpenRAVE::RaveGetSourceFilename(filename), line,
-                text.c_str());
-        }
+        openrave_message_level = OpenRAVE::Level_Error;
         break;
 
     case ompl::msg::LOG_NONE:
     default:
-        RAVELOG_ERROR("Unknown OMPL log level %d.\n", level);
+        RAVELOG_ERROR("Unknown OMPL log level '%d'.\n", level);
+    }
+
+    if (openrave_message_level >= openrave_threshold_level)
+    {
+        log4cxx::spi::LocationInfo const location_info(
+            OpenRAVE::RaveGetSourceFilename(filename), "", line);
+        OpenRAVE::RavePrintfA_DEBUGLEVEL(
+            OpenRAVE::RaveGetLogger(), location_info, text);
     }
 }
 

--- a/src/OMPLConversions.cpp
+++ b/src/OMPLConversions.cpp
@@ -70,10 +70,16 @@ void OpenRAVEHandler::log(std::string const &text, ompl::msg::LogLevel level,
 
     if (openrave_message_level >= openrave_threshold_level)
     {
+#ifdef OR_OMPL_HAS_LOG4CXX
         log4cxx::spi::LocationInfo const location_info(
             OpenRAVE::RaveGetSourceFilename(filename), "", line);
         OpenRAVE::RavePrintfA_DEBUGLEVEL(
             OpenRAVE::RaveGetLogger(), location_info, text);
+#else
+        OpenRAVE::RavePrintfA_DEBUGLEVEL("[%s:%d] %s\n",
+            OpenRAVE::RaveGetSourceFilename(filename), line,
+            text.c_str());
+#endif
     }
 }
 

--- a/src/OMPLConversions.cpp
+++ b/src/OMPLConversions.cpp
@@ -70,7 +70,7 @@ void OpenRAVEHandler::log(std::string const &text, ompl::msg::LogLevel level,
 
     if (openrave_message_level >= openrave_threshold_level)
     {
-#ifdef OR_OMPL_HAS_LOG4CXX
+#ifdef OPENRAVE_LOG4CXX
         log4cxx::spi::LocationInfo const location_info(
             OpenRAVE::RaveGetSourceFilename(filename), "", line);
         OpenRAVE::RavePrintfA_DEBUGLEVEL(


### PR DESCRIPTION
This may require some massaging to enable backwards compatibility with earlier versions of OpenRAVE.