### PR TITLE
Fixed OMPLPlannerParameters::serialize()

### DIFF
--- a/include/or_ompl/OMPLPlannerParameters.h
+++ b/include/or_ompl/OMPLPlannerParameters.h
@@ -86,14 +86,16 @@ protected:
         }
 #endif
 
-        O << "<seed>" << m_seed << "</seed>" << std::endl;
-        O << "<time_limit>" << m_timeLimit << "</time_limit>" << std::endl;
-        O << "<dat_filename>" << m_dat_filename << "</dat_filename>" << std::endl;
-        O << "<trajs_fileformat>" << m_trajs_fileformat << "</trajs_fileformat>" << std::endl;
+        O << "<seed>" << m_seed << "</seed>\n"
+          << "<time_limit>" << m_timeLimit << "</time_limit>\n"
+          << "<dat_filename>" << m_dat_filename << "</dat_filename>\n"
+          << "<trajs_fileformat>" << m_trajs_fileformat << "</trajs_fileformat>\n"
+          << "<do_baked>" << m_doBaked << "</do_baked>\n";
         BOOST_FOREACH(TSRChain::Ptr chain, m_tsrchains) {
-            O << "<tsr_chain>" << chain << "</tsr_chain>" << std::endl;
+            O << "<tsr_chain>";
+            chain->serialize(O);
+            O << "</tsr_chain>\n";
         }
-        O << "<do_baked>" << m_doBaked << "</do_baked>" << std::endl;
 
         return !!O;
     }
@@ -138,7 +140,7 @@ protected:
                 TSRChain::Ptr chain = boost::make_shared<TSRChain>();
                 bool success = chain->deserialize(_ss);
                 if(!success){
-                    RAVELOG_ERROR("failed to deserialize TSRChain");
+                    RAVELOG_ERROR("failed to deserialize TSRChain\n");
                 }else{
                     m_tsrchains.push_back(chain);
                 }

--- a/include/or_ompl/TSR.h
+++ b/include/or_ompl/TSR.h
@@ -37,10 +37,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <Eigen/Dense>
 
 namespace or_ompl {
-        
+
 class TSR {
 
-public: 
+public:
     typedef boost::shared_ptr<TSR> Ptr;
 
     /**
@@ -61,11 +61,18 @@ public:
         const Eigen::Matrix<double, 6, 2> &Bw);
 
     /**
-     * Deserialize a serialized TSR.  
-     *  
+     * Deserialize a serialized TSR.
+     *
      * @param ss The stream to read the serialized TSR from
      */
     bool deserialize(std::stringstream &ss);
+
+    /**
+     * Serialize a TSR Chain.
+     *
+     * @param ss The stream to read the serialized TSR from
+     */
+    void serialize(std::ostream& ss);
 
     /**
      * Compute the distance to the TSR
@@ -76,7 +83,7 @@ public:
 
     /**
      * Compute the displacement to the TSR
-     * 
+     *
      * @param ee_pose The pose of the end-effector in world frame
      */
     Eigen::Matrix<double, 6, 1> displacement(const Eigen::Affine3d &ee_pose) const;
@@ -87,7 +94,7 @@ public:
      * @return The sampled pose
      */
     Eigen::Affine3d sample(void) const;
-        
+
     /**
      * Sample a displacement transform from the TSR
      * @return The sampled transform
@@ -108,7 +115,7 @@ public:
      * @return The bounds specified for the TSR (Bw)
      */
     Eigen::Matrix<double, 6, 2> getBounds(void) const { return _Bw; }
-    
+
     /**
      * Output operator
      */
@@ -129,7 +136,7 @@ protected:
     Eigen::Matrix<double, 6, 2> _Bw;
     bool _initialized;
 };
-       
+
 } // namespace or_ompl
 
 #endif // OR_OMPL_TSR_H_

--- a/include/or_ompl/TSR.h
+++ b/include/or_ompl/TSR.h
@@ -60,12 +60,17 @@ public:
         const Eigen::Affine3d &Tw_e,
         const Eigen::Matrix<double, 6, 2> &Bw);
 
+    int manipulator_index() const;
+    std::string relative_body_name() const;
+    std::string relative_link_name() const;
+
     /**
      * Deserialize a serialized TSR.
      *
      * @param ss The stream to read the serialized TSR from
      */
     bool deserialize(std::stringstream &ss);
+    bool deserialize(std::istream &ss);
 
     /**
      * Serialize a TSR Chain.
@@ -134,6 +139,9 @@ protected:
     Eigen::Affine3d _Tw_e;
     Eigen::Affine3d _Tw_e_inv;
     Eigen::Matrix<double, 6, 2> _Bw;
+    int _manipulator_index;
+    std::string _relative_body_name;
+    std::string _relative_link_name;
     bool _initialized;
 };
 

--- a/include/or_ompl/TSRChain.h
+++ b/include/or_ompl/TSRChain.h
@@ -70,6 +70,7 @@ public:
      *
      * @param ss The stream to read the serialized TSR from
      */
+    bool deserialize(std::istream &ss);
     bool deserialize(std::stringstream &ss);
 
     /**

--- a/include/or_ompl/TSRChain.h
+++ b/include/or_ompl/TSRChain.h
@@ -51,7 +51,7 @@ public:
      * Constructor
      */
     TSRChain();
-    
+
     /**
      * Constructor
      *
@@ -60,17 +60,24 @@ public:
      * @param constrain True if the chain should be applied trajectory wide
      * @param tsrs The list of TSRs in the chain
      */
-    TSRChain(const bool &sample_start, 
-             const bool &sample_goal, 
+    TSRChain(const bool &sample_start,
+             const bool &sample_goal,
              const bool &constrain,
              const std::vector<TSR::Ptr> &tsrs);
 
     /**
-     * Deserialize a serialized TSR Chain.  
-     *  
+     * Deserialize a serialized TSR Chain.
+     *
      * @param ss The stream to read the serialized TSR from
      */
     bool deserialize(std::stringstream &ss);
+
+    /**
+     * Serialize a TSR Chain.
+     *
+     * @param ss The stream to read the serialized TSR from
+     */
+    void serialize(std::ostream& ss);
 
     /**
      * @return True if this chain should be used to sample a start
@@ -86,7 +93,7 @@ public:
      * @return True if this chain should be applied as a trajectory wide constraint
      */
     bool isTrajectoryConstraint() const { return _constrain; }
-    
+
 
     /**
      * @return The list of TSRs that make up this chain
@@ -120,7 +127,7 @@ private:
     std::vector<TSR::Ptr> _tsrs;
     TSRRobot::Ptr _tsr_robot;
 };
-       
+
 } // namespace or_ompl
 
 #endif // OR_OMPL_TSRCHAIN_H_

--- a/src/TSR.cpp
+++ b/src/TSR.cpp
@@ -37,94 +37,90 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using namespace or_ompl;
 
-TSR::TSR() : _initialized(false) {
+TSR::TSR()
+    : _initialized(false)
+{
 }
 
-TSR::TSR(const Eigen::Affine3d &T0_w, const Eigen::Affine3d &Tw_e, const Eigen::Matrix<double, 6, 2> &Bw) :
-    _T0_w(T0_w), _Tw_e(Tw_e), _Bw(Bw), _initialized(true) {
-
+TSR::TSR(
+        const Eigen::Affine3d &T0_w,
+        const Eigen::Affine3d &Tw_e,
+        const Eigen::Matrix<double, 6, 2> &Bw)
+    : _T0_w(T0_w)
+    , _Tw_e(Tw_e)
+    , _Bw(Bw)
+    , _manipulator_index(-1)
+    , _relative_body_name("NULL")
+    , _relative_link_name("")
+    , _initialized(true)
+{
     _T0_w_inv = _T0_w.inverse();
     _Tw_e_inv = _Tw_e.inverse();
-
 }
 
-bool TSR::deserialize(std::stringstream &ss) {
+bool TSR::deserialize(std::stringstream &ss)
+{
+    return deserialize(static_cast<std::istream &>(ss));
+}
 
-    // TODO: Do we need this stuff?
-    int manipind_ignored;
-    ss >> manipind_ignored;
+bool TSR::deserialize(std::istream &ss)
+{
+    // Set _initialized to false in case an error occurs.
+    _initialized = false;
 
-    std::string relativebodyname_ignored;
-    ss >> relativebodyname_ignored;
+    ss >> _manipulator_index
+       >> _relative_body_name;
 
-    if( relativebodyname_ignored != "NULL" )
-    {
-        std::string relativelinkname_ignored;
-        ss >> relativelinkname_ignored;
-    }
+    if(_relative_body_name != "NULL")
+        ss >> _relative_link_name;
 
     // Read in the T0_w matrix
-    double tmp;
-    for(unsigned int c=0; c < 3; c++){
-        for(unsigned int r=0; r < 3; r++){
-            ss >> tmp;
-            _T0_w.matrix()(r,c) = tmp;
-        }
-    }
+    for(unsigned int c=0; c < 3; c++)
+    for(unsigned int r=0; r < 3; r++)
+        ss >> _T0_w.matrix()(r,c);
 
-    for(unsigned int idx=0; idx < 3; idx++){
-        ss >> tmp;
-        _T0_w.translation()(idx) = tmp;
-    }
+    for(unsigned int idx=0; idx < 3; idx++)
+        ss >> _T0_w.translation()(idx);
 
     // Read in the Tw_e matrix
-    for(unsigned int c=0; c < 3; c++){
-        for(unsigned int r=0; r < 3; r++){
-            ss >> tmp;
-            _Tw_e.matrix()(r,c) = tmp;
-        }
-    }
+    for(unsigned int c=0; c < 3; c++)
+    for(unsigned int r=0; r < 3; r++)
+        ss >> _Tw_e.matrix()(r,c);
 
-    for(unsigned int idx=0; idx < 3; idx++){
-        ss >> tmp;
-        _Tw_e.translation()(idx) = tmp;
-    }
+    for(unsigned int idx=0; idx < 3; idx++)
+        ss >> _Tw_e.translation()(idx);
 
     // Read in the Bw matrix
-    for(unsigned int r=0; r < 6; r++){
-        for(unsigned int c=0; c < 2; c++){
-            ss >> tmp;
-            _Bw(r,c) = tmp;
-        }
-    }
+    for(unsigned int r=0; r < 6; r++)
+    for(unsigned int c=0; c < 2; c++)
+        ss >> _Bw(r,c);
+
+    // Check for an error.
+    if (!ss)
+        return false;
 
     _T0_w_inv = _T0_w.inverse();
     _Tw_e_inv = _Tw_e.inverse();
-
     _initialized = true;
 
-    return _initialized;
+    return true;
 }
 
 void TSR::serialize(std::ostream& ss)
 {
-    static const int manipind_ignored = 0;
-    static const std::string relativebodyname_ignored = "NULL";
-    static const std::string relativelinkname_ignored = "";
-
     if (!_initialized)
         throw std::runtime_error("TSR is not initialized.");
 
-    ss << manipind_ignored
-       << ' ' << relativebodyname_ignored;
+    ss << _manipulator_index
+       << ' ' << _relative_body_name;
 
-    if( relativebodyname_ignored != "NULL")
-        ss << ' ' << relativelinkname_ignored;
+    if(_relative_body_name != "NULL")
+        ss << ' ' << _relative_link_name;
 
     // T0_w matrix
     for(unsigned int c=0; c < 3; c++)
     for(unsigned int r=0; r < 3; r++)
-        ss << ' ' << _T0_w.matrix()(r,c);
+        ss << ' ' << _T0_w.matrix()(r, c);
 
     for(unsigned int idx=0; idx < 3; idx++)
         ss << ' ' << _T0_w.translation()(idx);
@@ -132,7 +128,7 @@ void TSR::serialize(std::ostream& ss)
     // Tw_e matrix
     for(unsigned int c=0; c < 3; c++)
     for(unsigned int r=0; r < 3; r++)
-        ss << ' ' << _Tw_e.matrix()(r,c);
+        ss << ' ' << _Tw_e.matrix()(r, c);
 
     for(unsigned int idx=0; idx < 3; idx++)
         ss << ' ' << _Tw_e.translation()(idx);
@@ -140,7 +136,7 @@ void TSR::serialize(std::ostream& ss)
     // Read in the Bw matrix
     for(unsigned int r=0; r < 6; r++)
     for(unsigned int c=0; c < 2; c++)
-        ss << ' ' << _Bw(r,c);
+        ss << ' ' << _Bw(r, c);
 }
 
 Eigen::Matrix<double, 6, 1> TSR::distance(const Eigen::Affine3d &ee_pose) const {

--- a/src/TSRChain.cpp
+++ b/src/TSRChain.cpp
@@ -42,20 +42,35 @@ using OpenRAVE::openrave_exception;
 using OpenRAVE::ORE_Failed;
 
 
-TSRChain::TSRChain() : _initialized(false), _sample_start(false), _sample_goal(false), _constrain(false), _tsr_robot(TSRRobot::Ptr()) {
-
+TSRChain::TSRChain()
+    : _initialized(false)
+    , _sample_start(false)
+    , _sample_goal(false)
+    , _constrain(false)
+    , _tsr_robot()
+{
 }
 
 TSRChain::TSRChain(const bool &sample_start,
                    const bool &sample_goal,
                    const bool &constrain,
-                   const std::vector<TSR::Ptr> &tsrs) :
-    _initialized(true), _sample_start(sample_start), _sample_goal(sample_goal),
-    _constrain(constrain), _tsrs(tsrs), _tsr_robot(TSRRobot::Ptr()) {
-
+                   const std::vector<TSR::Ptr> &tsrs)
+    : _initialized(true)
+    , _sample_start(sample_start)
+    , _sample_goal(sample_goal)
+    , _constrain(constrain)
+    , _tsrs(tsrs)
+    , _tsr_robot()
+{
 }
 
-bool TSRChain::deserialize(std::stringstream &ss) {
+bool TSRChain::deserialize(std::stringstream &ss)
+{
+    return deserialize(static_cast<std::istream &>(ss));
+}
+
+bool TSRChain::deserialize(std::istream &ss)
+{
     int num_tsrs;
 
     ss >> _sample_start
@@ -65,7 +80,8 @@ bool TSRChain::deserialize(std::stringstream &ss) {
 
     _tsrs.clear();
 
-    for(int idx = 0; idx < num_tsrs; idx++){
+    for(int idx = 0; idx < num_tsrs; idx++)
+    {
         TSR::Ptr new_tsr = boost::make_shared<TSR>();
 
         if (!new_tsr->deserialize(ss)){
@@ -79,7 +95,8 @@ bool TSRChain::deserialize(std::stringstream &ss) {
 
     // TODO: Ignored are mmicbody name and mimicbodyjoints
 
-    if (!ss){
+    if (!ss)
+    {
         RAVELOG_ERROR("Failed deserializing TSRChain.\n");
         return false;
     }
@@ -160,8 +177,8 @@ Eigen::Matrix<double, 6, 1> TSRChain::distance(const Eigen::Affine3d &ee_pose) c
     return dist;
 }
 
-void TSRChain::setEnv(const OpenRAVE::EnvironmentBasePtr &penv) {
-
+void TSRChain::setEnv(const OpenRAVE::EnvironmentBasePtr &penv)
+{
     _tsr_robot = boost::make_shared<TSRRobot>(_tsrs, penv);
 
 }

--- a/src/TSRRobot.cpp
+++ b/src/TSRRobot.cpp
@@ -77,6 +77,12 @@ bool TSRRobot::construct() {
 
         TSR::Ptr tsr = _tsrs[i];
         Eigen::Matrix<double, 6, 2> Bw = tsr->getBounds();
+
+        if (tsr->relative_body_name() != "NULL")
+        {
+            RAVELOG_ERROR("[TSRRobot] ERROR: TSRs relative to a body is not supported.\n");
+            return _initialized;
+        }
         
         for(int j=0; j < 6; j++){
             


### PR DESCRIPTION
The `serialize()` function previously serialized a pointer to goal TSRs, instead of the contents of the TSR. This caused serialization to silently fail due to lack of error checking in `deserialize()`.

This commit adds error checking and correctly serializes the TSRs.

I discovered this when trying to merge https://github.com/personalrobotics/prpy/pull/311.
